### PR TITLE
docs(capture): accept local media contract

### DIFF
--- a/apps/mobile/scripts/test.cjs
+++ b/apps/mobile/scripts/test.cjs
@@ -5,7 +5,13 @@ const { spawnSync } = require('node:child_process');
 // `test` script runs this lane before the Jest component lane.
 const result = spawnSync(
   process.execPath,
-  ['--test', 'tests/scaffold.test.mjs', 'tests/tooling.test.mjs', 'tests/routes.test.mjs'],
+  [
+    '--test',
+    'tests/scaffold.test.mjs',
+    'tests/tooling.test.mjs',
+    'tests/routes.test.mjs',
+    'tests/media-contract.test.mjs',
+  ],
   { stdio: 'inherit' },
 );
 

--- a/apps/mobile/tests/media-contract.test.mjs
+++ b/apps/mobile/tests/media-contract.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(appRoot, '../..');
+const spec = readFileSync(join(repoRoot, 'planning/v1-prototype-spec.md'), 'utf8');
+const adr = readFileSync(
+  join(repoRoot, 'planning/decisions/ADR-0003-local-media-and-vignette-contract.md'),
+  'utf8',
+);
+const decisionsReadme = readFileSync(join(repoRoot, 'planning/decisions/README.md'), 'utf8');
+const backlog = readFileSync(join(repoRoot, 'planning/backlog/v1-github-backlog.md'), 'utf8');
+
+test('accepted local photo/video contract is explicit and durable', () => {
+  assert.match(spec, /issue #45/);
+  assert.match(spec, /`mediaKind` is either `photo` or `video`/);
+  assert.match(spec, /`durationSeconds: 3`/);
+  assert.match(spec, /video duration is 1–15 seconds/);
+  assert.match(spec, /`vignetteTreatment` is one of `flash`, `ccd`, `home-movie`, or `tape`/);
+  assert.match(spec, /does not claim to alter source pixels or\s+audio/);
+  assert.doesNotMatch(spec, /image posts/);
+
+  assert.match(adr, /\*\*Status:\*\* Accepted/);
+  assert.match(adr, /five weekly\s+contribution slots/);
+  assert.match(adr, /Photos use a fixed three\n  second display duration/);
+  assert.match(adr, /does not edit pixels, transcode, filter, or normalize audio/);
+  assert.match(adr, /must not expose\n  a URI, thumbnail, image, player, or share action/);
+  assert.match(decisionsReadme, /ADR-0003-local-media-and-vignette-contract\.md/);
+  assert.match(backlog, /Media-contract amendment/);
+  assert.match(backlog, /#45[\s\S]*block #14, #16, #22,\s*#24, and #46/);
+  assert.match(backlog, /#46 — Capture a still image/);
+});

--- a/evidence/issues/45/completion.md
+++ b/evidence/issues/45/completion.md
@@ -1,0 +1,48 @@
+# Issue 45 completion evidence
+
+- Issue: [#45 — Define local photo contribution and vignette treatment contract](https://github.com/Collaboration95/rewind-v1/issues/45)
+- Branch: `codex/45-local-photo-vignette-contract`
+- Implementation commit: [75dc5c8](https://github.com/Collaboration95/rewind-v1/commit/75dc5c88db20b179bb773c8a56ed6c4f3b238730)
+- Review PR: [#48](https://github.com/Collaboration95/rewind-v1/pull/48)
+
+## Scope delivered
+
+The accepted local media decision is recorded in the V1 specification and
+ADR-0003. Photos and videos use the same local contribution lifecycle and five
+weekly slots; videos use measured 1–15 second durations; photos use a fixed
+three-second display duration for quota and deterministic playlist ordering;
+and `vignetteTreatment` is original metadata-only preview/frame-overlay data.
+The specification, backlog amendment, and downstream issue comments preserve
+the no-gallery, no-editing, no-pixel-processing, pre-reveal privacy, and
+no-AWS boundaries.
+
+## Verification
+
+- `make check` — PASS (workflow parser, format check, lint, typecheck, seven Node contract tests, and one Jest/RNTL smoke test).
+- `npm run test -- --runInBand` from `apps/mobile/` — PASS (seven Node contract tests and one Jest/RNTL smoke test).
+- `npm run build:web` from `apps/mobile/` — PASS (Expo web export).
+- Planning-document Prettier check — PASS.
+- `git diff --check` — PASS.
+
+Relevant contract-test output:
+
+```text
+ℹ tests 7
+ℹ pass 7
+ℹ fail 0
+PASS tests/home-screen.test.tsx
+Tests: 1 passed, 1 total
+```
+
+## Planning evidence
+
+- [Accepted decision comment](https://github.com/Collaboration95/rewind-v1/issues/45#issuecomment-5466204576)
+- [#14 domain model amendment](https://github.com/Collaboration95/rewind-v1/issues/14#issuecomment-5466222844)
+- [#16 policy amendment](https://github.com/Collaboration95/rewind-v1/issues/16#issuecomment-5466222781)
+- [#22 video capture amendment](https://github.com/Collaboration95/rewind-v1/issues/22#issuecomment-5466222814)
+- [#24 vignette amendment](https://github.com/Collaboration95/rewind-v1/issues/24#issuecomment-5466222802)
+- [#46 still capture amendment](https://github.com/Collaboration95/rewind-v1/issues/46#issuecomment-5466222793)
+
+This decision ticket requires no device screenshot or media fixture. Validation
+uses only local text contracts and synthetic test data; no network, credential,
+personal media, or native capability is claimed.

--- a/planning/backlog/v1-github-backlog.md
+++ b/planning/backlog/v1-github-backlog.md
@@ -15,17 +15,17 @@ and agent handoffs.
 
 ## Epic hierarchy
 
-| Key | Epic outcome | Initial status |
-| --- | --- | --- |
-| [`v1-epic-foundation`](https://github.com/Collaboration95/rewind-v1/issues/1) | A repeatable Expo workspace and agent delivery rails. | Backlog |
-| [`v1-epic-domain`](https://github.com/Collaboration95/rewind-v1/issues/2) | Local data, policies, clock, and simulation behaviour are deterministic. | Backlog |
-| [`v1-epic-group`](https://github.com/Collaboration95/rewind-v1/issues/3) | Seeded profiles can safely act within one local private group. | Backlog |
-| [`v1-epic-capture`](https://github.com/Collaboration95/rewind-v1/issues/4) | A real device can capture, persist, lock, and manage a contribution. | Backlog |
-| [`v1-epic-reminders`](https://github.com/Collaboration95/rewind-v1/issues/5) | Local reminder preference, delivery, and fallback are observable. | Backlog |
-| [`v1-epic-chat`](https://github.com/Collaboration95/rewind-v1/issues/6) | Seeded group members can send/reply/react to persistent local chat. | Backlog |
-| [`v1-epic-archive`](https://github.com/Collaboration95/rewind-v1/issues/7) | A simulation can reveal, play, archive, and share a local capsule playlist. | Backlog |
-| [`v1-epic-quality`](https://github.com/Collaboration95/rewind-v1/issues/8) | Automated checks and device evidence prove the V1 definition of done. | Backlog |
-| [`m2-epic-cloud-transition`](https://github.com/Collaboration95/rewind-v1/issues/9) | Future cloud/adapter/Terraform work is visible but not prematurely started. | Blocked |
+| Key                                                                                 | Epic outcome                                                                | Initial status |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | -------------- |
+| [`v1-epic-foundation`](https://github.com/Collaboration95/rewind-v1/issues/1)       | A repeatable Expo workspace and agent delivery rails.                       | Backlog        |
+| [`v1-epic-domain`](https://github.com/Collaboration95/rewind-v1/issues/2)           | Local data, policies, clock, and simulation behaviour are deterministic.    | Backlog        |
+| [`v1-epic-group`](https://github.com/Collaboration95/rewind-v1/issues/3)            | Seeded profiles can safely act within one local private group.              | Backlog        |
+| [`v1-epic-capture`](https://github.com/Collaboration95/rewind-v1/issues/4)          | A real device can capture, persist, lock, and manage a contribution.        | Backlog        |
+| [`v1-epic-reminders`](https://github.com/Collaboration95/rewind-v1/issues/5)        | Local reminder preference, delivery, and fallback are observable.           | Backlog        |
+| [`v1-epic-chat`](https://github.com/Collaboration95/rewind-v1/issues/6)             | Seeded group members can send/reply/react to persistent local chat.         | Backlog        |
+| [`v1-epic-archive`](https://github.com/Collaboration95/rewind-v1/issues/7)          | A simulation can reveal, play, archive, and share a local capsule playlist. | Backlog        |
+| [`v1-epic-quality`](https://github.com/Collaboration95/rewind-v1/issues/8)          | Automated checks and device evidence prove the V1 definition of done.       | Backlog        |
+| [`m2-epic-cloud-transition`](https://github.com/Collaboration95/rewind-v1/issues/9) | Future cloud/adapter/Terraform work is visible but not prematurely started. | Blocked        |
 
 ## Dependency-ordered child issues
 
@@ -34,44 +34,61 @@ dependency-free ticket after reviewing its prerequisite evidence. This prevents
 the solo local agent from implementing speculative work against an unstable
 foundation.
 
-| Order | Key | Child issue | Area | Size | Risk | Depends on | Initial status |
-| ---: | --- | --- | --- | --- | --- | --- | --- |
-| 1 | `v1-foundation-001` | Scaffold the Expo mobile workspace under `apps/mobile` | Mobile | S | Medium | — | **Ready** |
-| 2 | `v1-foundation-002` | Add mobile quality rails and baseline GitHub Actions checks | DevEx | S | Low | 001 | Backlog |
-| 3 | `v1-foundation-003` | Add original visual tokens and four-tab route shell | Mobile | M | Low | 001, 002 | Backlog |
-| 4 | `v1-foundation-004` | Establish testing, accessibility, and evidence selector contract | Quality | S | Low | 001, 002 | Backlog |
-| 5 | `v1-domain-001` | Define framework-free local domain models and repository ports | Domain | M | Medium | 002 | Backlog |
-| 6 | `v1-domain-002` | Implement SQLite migrations, seed fixtures, and resettable local repository | Domain | M | Medium | 001, 001-domain | Backlog |
-| 7 | `v1-domain-003` | Implement contribution budget and lifecycle policy state machine | Domain | M | High | 001-domain | Backlog |
-| 8 | `v1-domain-004` | Add deterministic simulation clock and local capsule assembler | Domain | M | High | 001-domain, 003-domain | Backlog |
-| 9 | `v1-group-001` | Add local profile session switching and membership guard | Group | M | Medium | 002-domain, 003-foundation | Backlog |
-| 10 | `v1-group-002` | Build local group home, prompt, quota, and invite-preview states | Experience | M | Low | 001-group, 003-foundation, 003-domain | Backlog |
-| 11 | `v1-group-003` | Prove local group authorization boundaries with negative policy tests | Domain | S | Medium | 001-group, 003-domain | Backlog |
-| 12 | `v1-capture-001` | Add device capability ports and permission-state UI | Mobile | M | High | 003-foundation, 001-group | Backlog |
-| 13 | `v1-capture-002` | Record a capped vertical video and persist its local file | Mobile | L | High | 001-capture, 002-domain | Backlog |
-| 14 | `v1-capture-003` | Review, submit, process-simulate, and lock a contribution | Capture | L | High | 002-capture, 003-domain, 002-group | Backlog |
-| 15 | `v1-capture-004` | Implement original preset overlays and capture haptic feedback | Experience | M | Medium | 002-capture, 003-foundation | Backlog |
-| 16 | `v1-capture-005` | Handle deletion, failure, retry, and lock-safe UI paths | Capture | M | High | 003-capture, 004-domain | Backlog |
-| 17 | `v1-reminders-001` | Persist local reminder preferences and schedule a device notification | Mobile | M | Medium | 001-group, 002-domain | Backlog |
-| 18 | `v1-reminders-002` | Handle reminder tap/deep link and in-app notification fallback | Mobile | M | Medium | 001-reminders, 003-foundation | Backlog |
-| 19 | `v1-reminders-003` | Build local settings, permission recovery, and safe demo reset controls | Experience | M | Medium | 001-reminders, 002-reminders | Backlog |
-| 20 | `v1-chat-001` | Persist profile-aware local group text messages | Chat | M | Medium | 001-group, 002-domain, 003-foundation | Backlog |
-| 21 | `v1-chat-002` | Add reply threads and one reaction type to local chat | Chat | M | Low | 001-chat | Backlog |
-| 22 | `v1-chat-003` | Add chat access guards, empty/error states, and interaction evidence | Chat | S | Medium | 002-chat, 003-group, 004-foundation | Backlog |
-| 23 | `v1-archive-001` | Build developer simulation controls for cycle advance and reveal | Archive | M | High | 004-domain, 005-capture | Backlog |
-| 24 | `v1-archive-002` | Render revealed archive playlist and play local captured media | Mobile | L | High | 001-archive, 002-capture, 003-foundation | Backlog |
-| 25 | `v1-archive-003` | Share a revealed local item and protect unrevealed export | Mobile | M | High | 002-archive, 003-group | Backlog |
-| 26 | `v1-quality-001` | Complete deterministic domain-policy coverage and failure fixtures | Quality | M | High | 005-capture, 003-group, 004-domain | Backlog |
-| 27 | `v1-quality-002` | Automate the V1 smoke journey with Maestro and synthetic screenshots | Quality | L | High | 002-archive, 002-reminders, 002-chat, 004-foundation | Backlog |
-| 28 | `v1-quality-003` | Audit accessibility, reduced motion, and device-specific failure states | Quality | M | Medium | 005-capture, 003-reminders, 003-chat, 002-archive | Backlog |
-| 29 | `v1-quality-004` | Run V1 release rehearsal and publish evidence-oriented handoff | Quality | M | Medium | 001-quality, 002-quality, 003-quality | Backlog |
-| 30 | `m2-cloud-001` | Define local-to-cloud adapter and data-contract transition plan | Cloud | M | High | 004-quality | Blocked |
-| 31 | `m2-cloud-002` | Spike a modular-monolith backend and local integration boundary | Cloud | L | High | 001-cloud | Blocked |
-| 32 | `m2-cloud-003` | Design reviewed Terraform modules and safe state boundary | Infrastructure | L | High | 001-cloud, 002-cloud | Blocked |
+| Order | Key                 | Child issue                                                                 | Area           | Size | Risk   | Depends on                                           | Initial status |
+| ----: | ------------------- | --------------------------------------------------------------------------- | -------------- | ---- | ------ | ---------------------------------------------------- | -------------- |
+|     1 | `v1-foundation-001` | Scaffold the Expo mobile workspace under `apps/mobile`                      | Mobile         | S    | Medium | —                                                    | **Ready**      |
+|     2 | `v1-foundation-002` | Add mobile quality rails and baseline GitHub Actions checks                 | DevEx          | S    | Low    | 001                                                  | Backlog        |
+|     3 | `v1-foundation-003` | Add original visual tokens and four-tab route shell                         | Mobile         | M    | Low    | 001, 002                                             | Backlog        |
+|     4 | `v1-foundation-004` | Establish testing, accessibility, and evidence selector contract            | Quality        | S    | Low    | 001, 002                                             | Backlog        |
+|     5 | `v1-domain-001`     | Define framework-free local domain models and repository ports              | Domain         | M    | Medium | 002                                                  | Backlog        |
+|     6 | `v1-domain-002`     | Implement SQLite migrations, seed fixtures, and resettable local repository | Domain         | M    | Medium | 001, 001-domain                                      | Backlog        |
+|     7 | `v1-domain-003`     | Implement contribution budget and lifecycle policy state machine            | Domain         | M    | High   | 001-domain                                           | Backlog        |
+|     8 | `v1-domain-004`     | Add deterministic simulation clock and local capsule assembler              | Domain         | M    | High   | 001-domain, 003-domain                               | Backlog        |
+|     9 | `v1-group-001`      | Add local profile session switching and membership guard                    | Group          | M    | Medium | 002-domain, 003-foundation                           | Backlog        |
+|    10 | `v1-group-002`      | Build local group home, prompt, quota, and invite-preview states            | Experience     | M    | Low    | 001-group, 003-foundation, 003-domain                | Backlog        |
+|    11 | `v1-group-003`      | Prove local group authorization boundaries with negative policy tests       | Domain         | S    | Medium | 001-group, 003-domain                                | Backlog        |
+|    12 | `v1-capture-001`    | Add device capability ports and permission-state UI                         | Mobile         | M    | High   | 003-foundation, 001-group                            | Backlog        |
+|    13 | `v1-capture-002`    | Record a capped vertical video and persist its local file                   | Mobile         | L    | High   | 001-capture, 002-domain                              | Backlog        |
+|    14 | `v1-capture-003`    | Review, submit, process-simulate, and lock a contribution                   | Capture        | L    | High   | 002-capture, 003-domain, 002-group                   | Backlog        |
+|    15 | `v1-capture-004`    | Implement original preset overlays and capture haptic feedback              | Experience     | M    | Medium | 002-capture, 003-foundation                          | Backlog        |
+|    16 | `v1-capture-005`    | Handle deletion, failure, retry, and lock-safe UI paths                     | Capture        | M    | High   | 003-capture, 004-domain                              | Backlog        |
+|    17 | `v1-reminders-001`  | Persist local reminder preferences and schedule a device notification       | Mobile         | M    | Medium | 001-group, 002-domain                                | Backlog        |
+|    18 | `v1-reminders-002`  | Handle reminder tap/deep link and in-app notification fallback              | Mobile         | M    | Medium | 001-reminders, 003-foundation                        | Backlog        |
+|    19 | `v1-reminders-003`  | Build local settings, permission recovery, and safe demo reset controls     | Experience     | M    | Medium | 001-reminders, 002-reminders                         | Backlog        |
+|    20 | `v1-chat-001`       | Persist profile-aware local group text messages                             | Chat           | M    | Medium | 001-group, 002-domain, 003-foundation                | Backlog        |
+|    21 | `v1-chat-002`       | Add reply threads and one reaction type to local chat                       | Chat           | M    | Low    | 001-chat                                             | Backlog        |
+|    22 | `v1-chat-003`       | Add chat access guards, empty/error states, and interaction evidence        | Chat           | S    | Medium | 002-chat, 003-group, 004-foundation                  | Backlog        |
+|    23 | `v1-archive-001`    | Build developer simulation controls for cycle advance and reveal            | Archive        | M    | High   | 004-domain, 005-capture                              | Backlog        |
+|    24 | `v1-archive-002`    | Render revealed archive playlist and play local captured media              | Mobile         | L    | High   | 001-archive, 002-capture, 003-foundation             | Backlog        |
+|    25 | `v1-archive-003`    | Share a revealed local item and protect unrevealed export                   | Mobile         | M    | High   | 002-archive, 003-group                               | Backlog        |
+|    26 | `v1-quality-001`    | Complete deterministic domain-policy coverage and failure fixtures          | Quality        | M    | High   | 005-capture, 003-group, 004-domain                   | Backlog        |
+|    27 | `v1-quality-002`    | Automate the V1 smoke journey with Maestro and synthetic screenshots        | Quality        | L    | High   | 002-archive, 002-reminders, 002-chat, 004-foundation | Backlog        |
+|    28 | `v1-quality-003`    | Audit accessibility, reduced motion, and device-specific failure states     | Quality        | M    | Medium | 005-capture, 003-reminders, 003-chat, 002-archive    | Backlog        |
+|    29 | `v1-quality-004`    | Run V1 release rehearsal and publish evidence-oriented handoff              | Quality        | M    | Medium | 001-quality, 002-quality, 003-quality                | Backlog        |
+|    30 | `m2-cloud-001`      | Define local-to-cloud adapter and data-contract transition plan             | Cloud          | M    | High   | 004-quality                                          | Blocked        |
+|    31 | `m2-cloud-002`      | Spike a modular-monolith backend and local integration boundary             | Cloud          | L    | High   | 001-cloud                                            | Blocked        |
+|    32 | `m2-cloud-003`      | Design reviewed Terraform modules and safe state boundary                   | Infrastructure | L    | High   | 001-cloud, 002-cloud                                 | Blocked        |
 
 `001-domain` in the table is shorthand for `v1-domain-001`; the remote issue
 bodies spell out full stable keys and issue numbers so an agent does not need to
 infer this shorthand.
+
+## Media-contract amendment
+
+On 2026-08-30, [#45 — Define local photo contribution and vignette treatment
+contract](https://github.com/Collaboration95/rewind-v1/issues/45) was added as a
+decision gate before domain and media implementation. Its accepted contract is
+recorded in [`ADR-0003`](../decisions/ADR-0003-local-media-and-vignette-contract.md):
+photos and videos are local contributions, photos account for a fixed three
+display seconds, and vignettes are metadata-only original preview/frame
+overlays. The existing issue dependency links make #45 block #14, #16, #22,
+#24, and #46.
+
+[#46 — Capture a still image and persist its local
+file](https://github.com/Collaboration95/rewind-v1/issues/46) follows the domain,
+profile, and capability foundations and reuses the same contribution lifecycle
+and pre-reveal privacy gate. It is a camera-only still capture ticket; gallery
+import and image editing remain out of scope.
 
 ## Ticket body standard
 

--- a/planning/decisions/ADR-0003-local-media-and-vignette-contract.md
+++ b/planning/decisions/ADR-0003-local-media-and-vignette-contract.md
@@ -1,0 +1,48 @@
+# ADR-0003: Keep photo/video contributions local with metadata-only vignettes
+
+**Status:** Accepted  
+**Date:** 2026-08-30  
+**Issue:** [#45](https://github.com/Collaboration95/rewind-v1/issues/45)
+
+## Context
+
+The original V1 specification described video capture while later local feature
+planning introduced still-image capture and vignette treatments. Without one
+shared contract, quota accounting, domain state, archive ordering, and the
+pre-reveal privacy gate could diverge between photo and video paths.
+
+## Decision
+
+V1 treats photos and videos as local contributions with a shared lifecycle:
+
+- `mediaKind` is `photo` or `video`; either kind consumes one of five weekly
+  contribution slots.
+- Videos use their measured 1–15 second duration. Photos use a fixed three
+  second display duration for quota accounting and deterministic playlist
+  ordering. This is display metadata, not generated video.
+- `vignetteTreatment` is one of `flash`, `ccd`, `home-movie`, or `tape`. The
+  treatment is an original preview/frame-overlay selection stored as metadata;
+  V1 does not edit pixels, transcode, filter, or normalize audio.
+- Camera still capture is allowed; gallery import, image editing, public export,
+  cloud sync/storage, and personal media remain out of scope.
+- Accepted files may move from cache to app-managed local storage. Until reveal,
+  normal UI may show only safe aggregate metadata and status; it must not expose
+  a URI, thumbnail, image, player, or share action.
+
+Both kinds follow `captured → processing → locked → revealed → archived`, with
+the existing bounded failure/retry and one-delete policy.
+
+## Consequences
+
+- Domain policy can validate one duration/quota contract for both media kinds
+  without importing Expo or a storage implementation.
+- SQLite and capture adapters can persist the media kind, fixed/measured
+  duration, treatment metadata, and local URI without storing media blobs.
+- Archive can order local contributions consistently without pretending to
+  render a compiled film.
+- Device work must provide separate permission/file evidence for photo and video
+  capture, while tests can use synthetic fixtures without camera access.
+
+This decision amends the V1 scope where it previously listed image posts as out
+of scope; source-material copies remain immutable. The authoritative scope is
+[`v1-prototype-spec.md`](../v1-prototype-spec.md).

--- a/planning/decisions/README.md
+++ b/planning/decisions/README.md
@@ -6,3 +6,4 @@ supersedes it and link both records.
 
 - [`ADR-0001-v1-local-first.md`](ADR-0001-v1-local-first.md)
 - [`ADR-0002-repository-topology.md`](ADR-0002-repository-topology.md)
+- [`ADR-0003-local-media-and-vignette-contract.md`](ADR-0003-local-media-and-vignette-contract.md)

--- a/planning/v1-prototype-spec.md
+++ b/planning/v1-prototype-spec.md
@@ -8,13 +8,13 @@ private group time-capsule product; it is not a submission build or cloud MVP.
 ## 1. Outcome
 
 V1 makes the future product's phone experience tangible before any cloud work:
-one person can use a real phone to record a short video, persist it locally,
-lock it under a simulated group policy, receive a local reminder, switch among
-seeded members, chat, advance a demo clock, reveal a locally assembled capsule,
-play it, and invoke the device share sheet.
+one person can use a real phone to capture a still photo or short video, persist
+it locally, lock it under a simulated group policy, receive a local reminder,
+switch among seeded members, chat, advance a demo clock, reveal a locally
+assembled capsule, play it, and invoke the device share sheet.
 
 The primary learning outcome is end-to-end React Native/Expo practice across
-permissions, camera recording, files, local storage, notifications, navigation,
+permissions, camera capture, files, local storage, notifications, navigation,
 accessibility, device testing, CI, Git/GitHub, and agent-led incremental work.
 It does **not** prove multi-user networking, OIDC, cloud media processing, or
 production privacy/security.
@@ -23,13 +23,16 @@ production privacy/security.
 
 ### In scope — real local phone operations
 
-- iOS/Android camera and microphone permission request, denial/retry state,
-  front/back selection, and vertical video recording capped at 15 seconds.
-- Capture review with discard/re-record; persist the accepted file from cache to
-  the app document directory and persist its metadata in local SQLite.
+- iOS/Android camera permission request, denial/retry state, front/back
+  selection, still-photo capture, and vertical video recording capped at 15
+  seconds. Video also requests microphone permission.
+- Capture review with discard/re-record; persist the accepted photo or video file
+  from cache to the app document directory and persist its metadata in local
+  SQLite.
 - Original visual camera shell: a selectable `Flash`, `CCD`, `Home Movie`, or
-  `Tape` preset represented by original overlay treatment and stored metadata.
-  It does not claim to alter video pixels yet.
+  `Tape` preset represented by an original preview/frame overlay and stored
+  metadata for either media kind. It does not claim to alter source pixels or
+  audio.
 - On-device haptic feedback for record, successful lock, and reveal.
 - Local profile switcher for five seeded people in one seeded private group;
   profile data is a demo device control, never sign-in.
@@ -43,22 +46,22 @@ production privacy/security.
   authored as the currently selected simulated member.
 - A visible developer-only simulation console for advancing/resetting a
   deterministic clock and moving a cycle to reveal.
-- A locally generated capsule playlist ordered by capture time; archive video
-  playback and the native share sheet after reveal.
+- A locally generated capsule playlist ordered by capture time; archive playback
+  of local captured media and the native share sheet after reveal.
 - Original camera-first, dark, nostalgic social-feed visual language using
   familiar tab/feed patterns, rather than copied screens or assets.
 
 ### Simulated in V1
 
-| Future product behaviour | V1 simulation and label |
-| --- | --- |
-| OIDC, invite links, 2–10 real users | Seeded profiles and a local invite-preview screen. “Local demo only” is always visible in developer mode. |
-| Asynchronous upload/FFmpeg job | A deterministic local processing timer/state sequence with failure/retry test controls. |
-| Actual filter/transcode/audio normalization | Preset metadata and visual overlay only; source video is otherwise untouched. |
-| Four-week cycle and scheduling service | Configurable local clock; one-minute demo, one-day demo, and four-week-equivalent policy modes. |
-| Scheduled server push to many devices | Device-local notification only, plus in-app log. |
-| Compiled group film in storage | A local ordered playlist; no media concatenation/re-encode. |
-| Secure download URL | Native local share sheet for an already-local revealed file. |
+| Future product behaviour                    | V1 simulation and label                                                                                           |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| OIDC, invite links, 2–10 real users         | Seeded profiles and a local invite-preview screen. “Local demo only” is always visible in developer mode.         |
+| Asynchronous upload/FFmpeg job              | A deterministic local processing timer/state sequence with failure/retry test controls.                           |
+| Actual filter/transcode/audio normalization | Vignette-treatment metadata and visual overlay only; source photo/video pixels and audio are otherwise untouched. |
+| Four-week cycle and scheduling service      | Configurable local clock; one-minute demo, one-day demo, and four-week-equivalent policy modes.                   |
+| Scheduled server push to many devices       | Device-local notification only, plus in-app log.                                                                  |
+| Compiled group film in storage              | A local ordered playlist; no media concatenation/re-encode.                                                       |
+| Secure download URL                         | Native local share sheet for an already-local revealed file.                                                      |
 
 ### Explicitly out of scope
 
@@ -67,12 +70,12 @@ production privacy/security.
   third-party auth, Expo push service, API routes, Terraform execution, or EAS
   cloud build/deploy.
 - Real multi-device synchronization, real invitation delivery, public feeds,
-  profiles, followers, gallery import, image posts, attachment chat, read
+  profiles, followers, gallery import, image editing, attachment chat, read
   receipts, edit/delete messages, live stream, public sharing, or app-store
   publication.
-- Actual non-destructive video trimming, true post-processing, custom GPU
-  filters, FFmpeg, merged media output, thumbnail extraction, licensed music,
-  or a claim that a demo profile provides security.
+- Actual media trimming/editing, true post-processing, custom GPU filters,
+  FFmpeg, merged media output, thumbnail extraction, licensed music, or a claim
+  that a demo profile provides security.
 - Copying Dazz Cam, Instagram, Lapse, 1SE, or another product's brand, source,
   assets, filters, visual design, camera names, or text.
 
@@ -82,11 +85,12 @@ production privacy/security.
    profile and the one seeded group.
 2. On **Home**, see the current prompt, simulated time left, weekly quota, and
    lock-safe group activity (no playable unrevealed clips).
-3. Go to **Camera**, approve camera/microphone permissions, choose a preset,
-   record up to 15 seconds, then review it.
-4. Accept the clip. Rewind copies it into app storage, records its metadata,
+3. Go to **Camera**, approve the required camera permission (and microphone for
+   video), choose a media kind and preset, capture a photo or record up to 15
+   seconds, then review it.
+4. Accept the capture. Rewind copies it into app storage, records its metadata,
    briefly shows `Processing`, and changes it to `Locked`; haptics confirm the
-   result. The clip cannot be replayed from the normal pre-reveal UI.
+   result. The capture cannot be replayed from the normal pre-reveal UI.
 5. Use the developer console to switch a profile, add a chat message/reply/
    reaction, advance time, or fire a short demo reminder.
 6. Move the clock through the reveal boundary. The capsule shows `Premiere`,
@@ -99,15 +103,15 @@ behaviours, not merely mocked screenshots.
 
 ## 4. Information architecture and screen contract
 
-| Route/screen | Purpose | Key observable controls |
-| --- | --- | --- |
-| `/(app)/home` | Group overview, prompt, quota, locked metadata, reveal status | Camera tab, chat tab, quota, developer-console access |
-| `/(app)/camera` | Record device video under a selected visual preset | permission retry, preset selector, camera flip, record/stop, timer |
-| `/(app)/capture-review` | Accept or discard the new local file | submit/lock, re-record, file/preset summary |
-| `/(app)/chat` | Local group text, replies, reactions | composer, reply, reaction, profile label |
-| `/(app)/archive` | Revealed capsules and local playback | capsule selector, player, share button |
-| `/(app)/settings` | Local reminder preference and app/device status | enable/disable, schedule, demo reminder, reset confirmation |
-| `/(dev)/simulation` | Seed profile, clock, failure and scenario controls | profile selector, time advance, reveal, reset, inject failure |
+| Route/screen            | Purpose                                                                | Key observable controls                                                                          |
+| ----------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `/(app)/home`           | Group overview, prompt, quota, locked metadata, reveal status          | Camera tab, chat tab, quota, developer-console access                                            |
+| `/(app)/camera`         | Capture a still photo or vertical video under a selected visual preset | permission retry, media-kind choice, preset selector, camera flip, shutter or record/stop, timer |
+| `/(app)/capture-review` | Accept or discard the new local media file                             | submit/lock, re-record, media-kind/file/preset summary                                           |
+| `/(app)/chat`           | Local group text, replies, reactions                                   | composer, reply, reaction, profile label                                                         |
+| `/(app)/archive`        | Revealed capsules and local playback                                   | capsule selector, player, share button                                                           |
+| `/(app)/settings`       | Local reminder preference and app/device status                        | enable/disable, schedule, demo reminder, reset confirmation                                      |
+| `/(dev)/simulation`     | Seed profile, clock, failure and scenario controls                     | profile selector, time advance, reveal, reset, inject failure                                    |
 
 Navigation is a four-tab shell: Home, Camera, Chat, Archive. Settings and the
 simulation console are secondary routes. The future product can retain the
@@ -123,7 +127,8 @@ Member(id, displayName, avatarSeed)
 Group(id, name, timezone, memberIds, prompt)
 Cycle(id, groupId, startAt, duration, status)
 Contribution(id, cycleId, memberId, capturedAt, durationSeconds,
-             preset, localUri, state, processingAttempt, deletedAt)
+             mediaKind, vignetteTreatment, localUri, state, processingAttempt,
+             deletedAt)
 Message(id, groupId, memberId, body, replyToId, createdAt)
 Reaction(id, messageId, memberId, emoji)
 Capsule(id, cycleId, contributionIds, status, revealedAt)
@@ -131,6 +136,23 @@ ReminderPreference(memberId, enabled, weekday, hour, minute, notificationId)
 SimulationClock(now, mode)
 AuditEvent(id, type, at, subjectId, metadata)
 ```
+
+### Local media contract
+
+The contract accepted in [issue #45](https://github.com/Collaboration95/rewind-v1/issues/45)
+is deliberately narrow:
+
+- `mediaKind` is either `photo` or `video`; both are local contributions and
+  consume one of the five weekly slots.
+- A video has its measured duration from 1–15 seconds. A photo stores exactly
+  `durationSeconds: 3` for quota accounting and deterministic playlist display
+  ordering. That value is not an instruction to generate a video segment.
+- `vignetteTreatment` is one of `flash`, `ccd`, `home-movie`, or `tape`. It is
+  original preview/frame-overlay metadata; it never edits source pixels,
+  transcodes media, or normalizes audio.
+- An accepted file may be copied from cache to the app-managed document
+  directory and its local URI persisted for local adapters. Before reveal,
+  normal UI still exposes no URI, thumbnail, image, player, or share action.
 
 ### Contribution state machine
 
@@ -144,8 +166,9 @@ recording → captured → processing → locked ───────→ reveal
 - Capture may begin only when the current member belongs to the local group,
   the cycle is collecting, the weekly clip count remains below five, and the
   current used duration plus the new clip is no more than 30 seconds.
-- A clip duration is 1–15 seconds. The capture adapter must stop at 15 seconds;
-  policy also rejects invalid test data.
+- A video duration is 1–15 seconds and the capture adapter must stop at 15
+  seconds. A photo contributes exactly three display seconds. Policy rejects
+  invalid test data for either media kind.
 - The first permitted deletion in a cycle-week restores its clip count/duration
   budget. A second delete is rejected with a clear reason and audit event.
 - Processing may fail by test control. Retry is explicit, bounded, idempotent,


### PR DESCRIPTION
## Summary

- formally accept the local photo/video contribution contract from #45;
- make photos and videos share five-slot quota and lifecycle semantics;
- define photos as a fixed three-second display-duration contribution;
- define `vignetteTreatment` as original metadata-only preview/frame treatment;
- reconcile the V1 specification, backlog, and ADRs;
- add a dependency-free contract test covering the durable planning amendment.

## Acceptance criteria

- [x] Photo/video lifecycle and quota semantics are unambiguous for domain-policy tests.
- [x] Vignette treatment is original metadata/preview UI, not image or video processing.
- [x] Affected issue contracts have the planning amendment and dependency links; #45 blocks #14, #16, #22, #24, and #46.
- [x] The local-first, no-AWS boundary is retained.

## Verification

- `make check` — PASS
- `npm run test -- --runInBand` from `apps/mobile/` — PASS (7 Node contract tests; 1 Jest/RNTL smoke test)
- `npm run build:web` from `apps/mobile/` — PASS
- planning-document Prettier check — PASS
- `git diff --check` — PASS

## Evidence

- [Issue completion evidence](https://github.com/Collaboration95/rewind-v1/blob/25b7b97867f03fda3b8fdf9ac7429f431cbe9e1c/evidence/issues/45/completion.md)
- [Accepted decision comment](https://github.com/Collaboration95/rewind-v1/issues/45#issuecomment-5466204576)
- [Planning amendment](https://github.com/Collaboration95/rewind-v1/blob/25b7b97867f03fda3b8fdf9ac7429f431cbe9e1c/planning/decisions/ADR-0003-local-media-and-vignette-contract.md)
- [Downstream issue amendments](https://github.com/Collaboration95/rewind-v1/issues/14#issuecomment-5466222844)

No device, network, credential, or personal-media evidence is required for this decision ticket.

Closes #45
