### PR TITLE
feat(domain): add framework-free models and ports

### DIFF
--- a/.github/workflows/mobile-quality.yml
+++ b/.github/workflows/mobile-quality.yml
@@ -4,11 +4,13 @@ on:
   push:
     paths:
       - "apps/mobile/**"
+      - "packages/domain/**"
       - "Makefile"
       - ".github/workflows/mobile-quality.yml"
   pull_request:
     paths:
       - "apps/mobile/**"
+      - "packages/domain/**"
       - "Makefile"
       - ".github/workflows/mobile-quality.yml"
   workflow_dispatch:

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -75,9 +75,11 @@ and owned at runtime by `components/tokens.ts`.
 The workspace has two complementary test lanes. The dependency-free Node
 contract tests cover Router/config, tooling, and route/accessibility boundaries;
 the Jest + React Native Testing Library lane renders components under the
-Expo-compatible `jest-expo` preset. `npm run test` runs both lanes once and
-never starts watch mode. Use `npm run test:contracts` or `npm run test:unit` to
-run one lane locally.
+Expo-compatible `jest-expo` preset. The framework-free `packages/domain/`
+package also runs a direct Node fixture and dependency-boundary test. `npm run
+test` runs all three lanes once and never starts watch mode. Use
+`npm run test:contracts`, `npm run test:domain`, or `npm run test:unit` to run
+one lane locally.
 
 ## Selector and accessibility contract
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -47,9 +47,11 @@
     "format": "npm run format:write",
     "format:write": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && npm run typecheck:domain",
+    "typecheck:domain": "npm --prefix ../../packages/domain run typecheck",
     "test": "node scripts/test.cjs && jest --runInBand",
     "test:contracts": "node scripts/test.cjs",
+    "test:domain": "node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs",
     "test:unit": "jest --runInBand",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm run test"
   }

--- a/apps/mobile/scripts/test.cjs
+++ b/apps/mobile/scripts/test.cjs
@@ -6,11 +6,14 @@ const { spawnSync } = require('node:child_process');
 const result = spawnSync(
   process.execPath,
   [
+    '--experimental-strip-types',
     '--test',
     'tests/scaffold.test.mjs',
     'tests/tooling.test.mjs',
     'tests/routes.test.mjs',
     'tests/media-contract.test.mjs',
+    '../../packages/domain/tests/domain.test.mjs',
+    '../../packages/domain/tests/boundary.test.mjs',
   ],
   { stdio: 'inherit' },
 );

--- a/apps/mobile/tests/tooling.test.mjs
+++ b/apps/mobile/tests/tooling.test.mjs
@@ -8,6 +8,9 @@ const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = resolve(appRoot, '../..');
 const packageManifest = JSON.parse(readFileSync(join(appRoot, 'package.json'), 'utf8'));
 const jestConfig = readFileSync(join(appRoot, 'jest.config.cjs'), 'utf8');
+const domainManifest = JSON.parse(
+  readFileSync(join(repoRoot, 'packages/domain/package.json'), 'utf8'),
+);
 const makefile = readFileSync(join(repoRoot, 'Makefile'), 'utf8');
 const workflow = readFileSync(join(repoRoot, '.github/workflows/mobile-quality.yml'), 'utf8');
 
@@ -22,10 +25,24 @@ test('mobile quality scripts are deterministic and non-watch', () => {
   assert.equal(scripts.ios, 'npm run open:ios');
   assert.equal(scripts.android, 'npm run open:android');
   assert.equal(scripts.lint, 'eslint .');
-  assert.equal(scripts.typecheck, 'tsc --noEmit');
+  assert.match(scripts.typecheck, /^tsc --noEmit && npm run typecheck:domain$/);
+  assert.equal(scripts['typecheck:domain'], 'npm --prefix ../../packages/domain run typecheck');
   assert.match(scripts.test, /^node scripts\/test\.cjs && jest --runInBand$/);
   assert.equal(scripts['test:contracts'], 'node scripts/test.cjs');
+  assert.equal(
+    scripts['test:domain'],
+    'node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs',
+  );
   assert.equal(scripts['test:unit'], 'jest --runInBand');
+
+  assert.equal(
+    domainManifest.scripts.typecheck,
+    '../../apps/mobile/node_modules/.bin/tsc --noEmit -p tsconfig.json',
+  );
+  assert.equal(
+    domainManifest.scripts.test,
+    'node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs',
+  );
 
   assert.match(jestConfig, /preset: 'jest-expo'/);
   assert.match(jestConfig, /setupFilesAfterEnv: \['<rootDir>\/tests\/setup\.ts'\]/);
@@ -80,6 +97,7 @@ test('mobile workflow is cached, local-only, and emulator-free', () => {
   assert.match(workflow, /npm run lint/);
   assert.match(workflow, /npm run typecheck/);
   assert.match(workflow, /npm run test/);
+  assert.match(workflow, /packages\/domain\/\*\*/);
   assert.match(workflow, /npm run build:web/);
   assert.doesNotMatch(workflow, /secrets?\.|\beas\b|device farm|emulator/i);
 });

--- a/evidence/issues/14/completion.md
+++ b/evidence/issues/14/completion.md
@@ -1,0 +1,47 @@
+# Issue 14 completion evidence
+
+- Issue: [#14 — Define framework-free local domain models and repository ports](https://github.com/Collaboration95/rewind-v1/issues/14)
+- Branch: `codex/14-domain-models-repository-ports`
+- Implementation commit: [7b04bf9](https://github.com/Collaboration95/rewind-v1/commit/7b04bf9f969b70a135c6c5317c4490914db16540)
+
+## Scope delivered
+
+Added the `@rewind/domain` package with serializable V1 models for members,
+groups, cycles, contributions, messages, reactions, capsules, reminders,
+simulation clocks, and audit events. Contribution and cycle state vocabularies
+are explicit, the approved photo/video media contract is represented, and
+`SafeContributionSummary` omits local media locators for pre-reveal consumers.
+
+Repository ports cover each model plus clock, ID, transaction, and seed-reset
+capabilities without exposing SQLite, Expo, cloud, or route implementations.
+Five seeded synthetic members, a group, cycle, photo, video, message, capsule,
+reminder, clock, and audit fixture compile at the boundary.
+
+## Verification
+
+- `make check` — PASS (workflow parser, mobile format/lint/typecheck, ten Node contract tests, and one Jest/RNTL smoke test).
+- `npm run test -- --runInBand` from `apps/mobile/` — PASS (ten Node contract tests and one Jest/RNTL smoke test).
+- `npm --prefix packages/domain test` — PASS (three direct pure-domain tests).
+- `npm --prefix packages/domain run typecheck` — PASS.
+- `npm run build:web` from `apps/mobile/` — PASS on the unchanged app shell.
+- `git diff --check` — PASS.
+
+Relevant pure-domain output:
+
+```text
+ℹ tests 3
+ℹ pass 3
+ℹ fail 0
+```
+
+The boundary test scans all domain source imports and rejects React, React
+Native, Expo, SQLite, AWS, Cognito, Terraform, and remote URLs. The fixture
+test imports the TypeScript source directly with Node's type stripping, so it
+does not render a UI or require a device, network, credential, or media file.
+
+## Limitations
+
+This ticket defines contracts only. SQLite persistence, policy transitions,
+device capabilities, and route consumers remain in their dependency-ordered
+issues. The committed fixture uses synthetic metadata and `file:///synthetic/`
+locators only; it contains no media blobs or personal data.

--- a/packages/README.md
+++ b/packages/README.md
@@ -6,5 +6,6 @@ Reusable product code belongs here. Planned boundaries are:
   repository ports.
 - [`ui/`](ui/README.md) — shared Rewind visual primitives and tokens.
 
-Do not create packages until an issue gives them a concrete consumer and
-verification path.
+Create or extend a package only when an issue gives it a concrete consumer and
+verification path. The active [`domain/`](domain/README.md) package is the
+framework-free boundary established by issue #14.

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -1,5 +1,20 @@
-# Domain package placeholder
+# Rewind domain package
 
-This future package will hold framework-independent time-capsule rules:
-contribution budgets, cycle/reveal transitions, authorization policy, and typed
-ports. It must not import React Native, Expo, or cloud SDKs.
+This package owns framework-independent V1 models, state vocabulary, local-safe
+view types, repository ports, deterministic fixtures, and time/transaction
+capabilities. It must not import React Native, Expo, SQLite, cloud SDKs, route
+modules, or vendor-specific clients.
+
+The package is intentionally implementation-free in this slice. Local SQLite,
+device, and policy adapters implement these ports in later issues.
+
+Run its checks from the repository root:
+
+```bash
+npm --prefix packages/domain run typecheck
+npm --prefix packages/domain test
+```
+
+The pure test runs with Node's TypeScript type stripping and imports no UI. The
+synthetic fixture includes both a photo and a video so the approved media
+contract stays visible at the domain boundary.

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@rewind/domain",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "../../apps/mobile/node_modules/.bin/tsc --noEmit -p tsconfig.json",
+    "test": "node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs"
+  }
+}

--- a/packages/domain/src/fixtures.ts
+++ b/packages/domain/src/fixtures.ts
@@ -1,0 +1,128 @@
+import type {
+  AuditEvent,
+  Capsule,
+  Contribution,
+  Cycle,
+  Group,
+  Member,
+  Message,
+  Reaction,
+  ReminderPreference,
+  SimulationClock,
+} from "./models.ts";
+
+export interface DomainFixture {
+  readonly members: readonly Member[];
+  readonly group: Group;
+  readonly cycle: Cycle;
+  readonly contributions: readonly Contribution[];
+  readonly messages: readonly Message[];
+  readonly reactions: readonly Reaction[];
+  readonly capsule: Capsule;
+  readonly reminder: ReminderPreference;
+  readonly clock: SimulationClock;
+  readonly auditEvents: readonly AuditEvent[];
+}
+
+export const seededMembers: readonly Member[] = [
+  { id: "member-ava", displayName: "Ava", avatarSeed: "amber" },
+  { id: "member-ben", displayName: "Ben", avatarSeed: "blue" },
+  { id: "member-cleo", displayName: "Cleo", avatarSeed: "coral" },
+  { id: "member-dev", displayName: "Dev", avatarSeed: "green" },
+  { id: "member-finn", displayName: "Finn", avatarSeed: "violet" },
+];
+
+export const seededGroup: Group = {
+  id: "group-rewind-demo",
+  name: "The Sunday Room",
+  timezone: "Asia/Singapore",
+  memberIds: seededMembers.map((member) => member.id),
+  prompt: "What deserves a frame this week?",
+};
+
+export const seededCycle: Cycle = {
+  id: "cycle-rewind-demo",
+  groupId: seededGroup.id,
+  startAt: "2026-08-30T00:00:00.000Z",
+  durationSeconds: 7 * 24 * 60 * 60,
+  status: "collecting",
+};
+
+export const seededContributions: readonly Contribution[] = [
+  {
+    id: "contribution-photo-demo",
+    cycleId: seededCycle.id,
+    memberId: "member-ava",
+    capturedAt: "2026-08-30T08:00:00.000Z",
+    mediaKind: "photo",
+    durationSeconds: 3,
+    vignetteTreatment: "ccd",
+    localUri: "file:///synthetic/rewind-photo-demo.jpg",
+    state: "locked",
+    processingAttempt: 1,
+    deletedAt: null,
+  },
+  {
+    id: "contribution-video-demo",
+    cycleId: seededCycle.id,
+    memberId: "member-ben",
+    capturedAt: "2026-08-30T09:00:00.000Z",
+    mediaKind: "video",
+    durationSeconds: 5,
+    vignetteTreatment: "flash",
+    localUri: "file:///synthetic/rewind-video-demo.mov",
+    state: "locked",
+    processingAttempt: 1,
+    deletedAt: null,
+  },
+];
+
+export const seededMessages: readonly Message[] = [
+  {
+    id: "message-demo-1",
+    groupId: seededGroup.id,
+    memberId: "member-cleo",
+    body: "The light after rain counts.",
+    replyToId: null,
+    createdAt: "2026-08-30T10:00:00.000Z",
+  },
+];
+
+export const seededReactions: readonly Reaction[] = [];
+
+export const seededCapsule: Capsule = {
+  id: "capsule-rewind-demo",
+  cycleId: seededCycle.id,
+  contributionIds: seededContributions.map((contribution) => contribution.id),
+  status: "premiere",
+  revealedAt: null,
+};
+
+export const seededReminder: ReminderPreference = {
+  memberId: "member-ava",
+  enabled: false,
+  weekday: 0,
+  hour: 18,
+  minute: 0,
+  notificationId: null,
+};
+
+export const seededClock: SimulationClock = {
+  now: "2026-08-30T10:00:00.000Z",
+  mode: "demo-cycle",
+};
+
+export const seededAuditEvents: readonly AuditEvent[] = [];
+
+export const seededDomainFixture: DomainFixture = {
+  members: seededMembers,
+  group: seededGroup,
+  cycle: seededCycle,
+  contributions: seededContributions,
+  messages: seededMessages,
+  reactions: seededReactions,
+  capsule: seededCapsule,
+  reminder: seededReminder,
+  clock: seededClock,
+  auditEvents: seededAuditEvents,
+};

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./fixtures.ts";
+export * from "./models.ts";
+export * from "./ports.ts";

--- a/packages/domain/src/models.ts
+++ b/packages/domain/src/models.ts
@@ -1,0 +1,165 @@
+export type IsoTimestamp = string;
+
+export type MemberId = string;
+export type GroupId = string;
+export type CycleId = string;
+export type ContributionId = string;
+export type MessageId = string;
+export type ReactionId = string;
+export type CapsuleId = string;
+export type AuditEventId = string;
+
+export const MEDIA_KINDS = ["photo", "video"] as const;
+export type MediaKind = (typeof MEDIA_KINDS)[number];
+
+export const VIGNETTE_TREATMENTS = [
+  "flash",
+  "ccd",
+  "home-movie",
+  "tape",
+] as const;
+export type VignetteTreatment = (typeof VIGNETTE_TREATMENTS)[number];
+
+export const CYCLE_STATUSES = [
+  "collecting",
+  "reveal_pending",
+  "premiere",
+  "delayed",
+  "archived",
+] as const;
+export type CycleStatus = (typeof CYCLE_STATUSES)[number];
+
+export const CONTRIBUTION_STATES = [
+  "recording",
+  "captured",
+  "processing",
+  "locked",
+  "failed",
+  "revealed",
+  "archived",
+  "deleted",
+] as const;
+export type ContributionState = (typeof CONTRIBUTION_STATES)[number];
+
+export const CAPSULE_STATUSES = ["premiere", "archived"] as const;
+export type CapsuleStatus = (typeof CAPSULE_STATUSES)[number];
+
+export const SIMULATION_MODES = [
+  "real",
+  "demo-minute",
+  "demo-day",
+  "demo-cycle",
+] as const;
+export type SimulationMode = (typeof SIMULATION_MODES)[number];
+
+export interface Member {
+  readonly id: MemberId;
+  readonly displayName: string;
+  readonly avatarSeed: string;
+}
+
+export interface Group {
+  readonly id: GroupId;
+  readonly name: string;
+  readonly timezone: string;
+  readonly memberIds: readonly MemberId[];
+  readonly prompt: string;
+}
+
+export interface Cycle {
+  readonly id: CycleId;
+  readonly groupId: GroupId;
+  readonly startAt: IsoTimestamp;
+  readonly durationSeconds: number;
+  readonly status: CycleStatus;
+}
+
+export interface Contribution {
+  readonly id: ContributionId;
+  readonly cycleId: CycleId;
+  readonly memberId: MemberId;
+  readonly capturedAt: IsoTimestamp;
+  readonly mediaKind: MediaKind;
+  readonly durationSeconds: number;
+  readonly vignetteTreatment: VignetteTreatment;
+  readonly localUri: string | null;
+  readonly state: ContributionState;
+  readonly processingAttempt: number;
+  readonly deletedAt: IsoTimestamp | null;
+}
+
+export interface Message {
+  readonly id: MessageId;
+  readonly groupId: GroupId;
+  readonly memberId: MemberId;
+  readonly body: string;
+  readonly replyToId: MessageId | null;
+  readonly createdAt: IsoTimestamp;
+}
+
+export interface Reaction {
+  readonly id: ReactionId;
+  readonly messageId: MessageId;
+  readonly memberId: MemberId;
+  readonly emoji: string;
+}
+
+export interface Capsule {
+  readonly id: CapsuleId;
+  readonly cycleId: CycleId;
+  readonly contributionIds: readonly ContributionId[];
+  readonly status: CapsuleStatus;
+  readonly revealedAt: IsoTimestamp | null;
+}
+
+export interface ReminderPreference {
+  readonly memberId: MemberId;
+  readonly enabled: boolean;
+  readonly weekday: number;
+  readonly hour: number;
+  readonly minute: number;
+  readonly notificationId: string | null;
+}
+
+export interface SimulationClock {
+  readonly now: IsoTimestamp;
+  readonly mode: SimulationMode;
+}
+
+export type AuditMetadataValue = string | number | boolean | null;
+
+export interface AuditEvent {
+  readonly id: AuditEventId;
+  readonly type: string;
+  readonly at: IsoTimestamp;
+  readonly subjectId: string;
+  readonly metadata: Readonly<Record<string, AuditMetadataValue>>;
+}
+
+/**
+ * The normal pre-reveal UI may use this view, which intentionally has no local
+ * URI, thumbnail, or other media locator.
+ */
+export interface SafeContributionSummary {
+  readonly id: ContributionId;
+  readonly memberId: MemberId;
+  readonly capturedAt: IsoTimestamp;
+  readonly mediaKind: MediaKind;
+  readonly durationSeconds: number;
+  readonly vignetteTreatment: VignetteTreatment;
+  readonly state: ContributionState;
+}
+
+export function toSafeContributionSummary(
+  contribution: Contribution,
+): SafeContributionSummary {
+  return {
+    id: contribution.id,
+    memberId: contribution.memberId,
+    capturedAt: contribution.capturedAt,
+    mediaKind: contribution.mediaKind,
+    durationSeconds: contribution.durationSeconds,
+    vignetteTreatment: contribution.vignetteTreatment,
+    state: contribution.state,
+  };
+}

--- a/packages/domain/src/ports.ts
+++ b/packages/domain/src/ports.ts
@@ -1,0 +1,109 @@
+import type {
+  AuditEvent,
+  Capsule,
+  CapsuleId,
+  Contribution,
+  ContributionId,
+  Cycle,
+  CycleId,
+  Group,
+  GroupId,
+  IsoTimestamp,
+  Member,
+  MemberId,
+  Message,
+  MessageId,
+  Reaction,
+  ReactionId,
+  ReminderPreference,
+} from "./models.ts";
+
+export interface ClockPort {
+  now(): IsoTimestamp;
+}
+
+export interface IdGeneratorPort {
+  next(prefix: string): string;
+}
+
+export interface TransactionPort {
+  run<T>(operation: () => Promise<T>): Promise<T>;
+}
+
+export interface MemberRepositoryPort {
+  get(memberId: MemberId): Promise<Member | null>;
+  listByGroup(groupId: GroupId): Promise<readonly Member[]>;
+}
+
+export interface GroupRepositoryPort {
+  get(groupId: GroupId): Promise<Group | null>;
+}
+
+export interface CycleRepositoryPort {
+  get(cycleId: CycleId): Promise<Cycle | null>;
+  getCollecting(groupId: GroupId, at: IsoTimestamp): Promise<Cycle | null>;
+  save(cycle: Cycle): Promise<void>;
+}
+
+export interface ContributionRepositoryPort {
+  get(contributionId: ContributionId): Promise<Contribution | null>;
+  listByCycle(cycleId: CycleId): Promise<readonly Contribution[]>;
+  save(contribution: Contribution): Promise<void>;
+  remove(contributionId: ContributionId): Promise<void>;
+}
+
+export interface MessageRepositoryPort {
+  listByGroup(groupId: GroupId): Promise<readonly Message[]>;
+  get(messageId: MessageId): Promise<Message | null>;
+  save(message: Message): Promise<void>;
+}
+
+export interface ReactionRepositoryPort {
+  listByMessage(messageId: MessageId): Promise<readonly Reaction[]>;
+  save(reaction: Reaction): Promise<void>;
+  remove(reactionId: ReactionId): Promise<void>;
+}
+
+export interface CapsuleRepositoryPort {
+  get(capsuleId: CapsuleId): Promise<Capsule | null>;
+  getByCycle(cycleId: CycleId): Promise<Capsule | null>;
+  save(capsule: Capsule): Promise<void>;
+}
+
+export interface ReminderRepositoryPort {
+  get(memberId: MemberId): Promise<ReminderPreference | null>;
+  save(preference: ReminderPreference): Promise<void>;
+}
+
+export interface AuditRepositoryPort {
+  append(event: AuditEvent): Promise<void>;
+  list(subjectId?: string): Promise<readonly AuditEvent[]>;
+}
+
+export interface DomainRepositoryPort {
+  readonly members: MemberRepositoryPort;
+  readonly groups: GroupRepositoryPort;
+  readonly cycles: CycleRepositoryPort;
+  readonly contributions: ContributionRepositoryPort;
+  readonly messages: MessageRepositoryPort;
+  readonly reactions: ReactionRepositoryPort;
+  readonly capsules: CapsuleRepositoryPort;
+  readonly reminders: ReminderRepositoryPort;
+  readonly audit: AuditRepositoryPort;
+}
+
+export interface SeedResetPort {
+  resetToSeed(): Promise<void>;
+}
+
+/**
+ * The application layer receives these ports; it does not receive a database,
+ * SQLite connection, cloud client, or device module.
+ */
+export interface LocalDomainPorts {
+  readonly repository: DomainRepositoryPort;
+  readonly clock: ClockPort;
+  readonly ids: IdGeneratorPort;
+  readonly transaction: TransactionPort;
+  readonly seed: SeedResetPort;
+}

--- a/packages/domain/tests/boundary.test.mjs
+++ b/packages/domain/tests/boundary.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const sourceRoot = new URL("../src/", import.meta.url);
+const sourceFiles = readdirSync(sourceRoot).filter((file) =>
+  file.endsWith(".ts"),
+);
+const source = sourceFiles
+  .map((file) => readFileSync(new URL(file, sourceRoot), "utf8"))
+  .join("\n");
+const imports = [...source.matchAll(/\b(?:from|import)\s*['"][^'"]+['"]/g)]
+  .map(([statement]) => statement)
+  .join("\n");
+
+test("domain source stays independent of UI, persistence, and vendor modules", () => {
+  assert.ok(sourceFiles.length > 0);
+  assert.doesNotMatch(
+    imports,
+    /react-native|\breact\b|\bexpo\b|sqlite|aws|cognito|terraform/i,
+  );
+  assert.doesNotMatch(source, /https?:\/\//i);
+});

--- a/packages/domain/tests/domain.test.mjs
+++ b/packages/domain/tests/domain.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  CONTRIBUTION_STATES,
+  MEDIA_KINDS,
+  VIGNETTE_TREATMENTS,
+  seededDomainFixture,
+} from "../src/index.ts";
+import { toSafeContributionSummary } from "../src/models.ts";
+
+test("domain fixtures run outside the UI and cover the approved local media model", () => {
+  assert.equal(seededDomainFixture.members.length, 5);
+  assert.deepEqual(seededDomainFixture.group.memberIds, [
+    "member-ava",
+    "member-ben",
+    "member-cleo",
+    "member-dev",
+    "member-finn",
+  ]);
+  assert.deepEqual(MEDIA_KINDS, ["photo", "video"]);
+  assert.deepEqual(VIGNETTE_TREATMENTS, ["flash", "ccd", "home-movie", "tape"]);
+  assert.ok(CONTRIBUTION_STATES.includes("locked"));
+  assert.ok(CONTRIBUTION_STATES.includes("revealed"));
+
+  const photo = seededDomainFixture.contributions.find(
+    (contribution) => contribution.mediaKind === "photo",
+  );
+  const video = seededDomainFixture.contributions.find(
+    (contribution) => contribution.mediaKind === "video",
+  );
+
+  assert.equal(photo?.durationSeconds, 3);
+  assert.equal(video?.durationSeconds, 5);
+});
+
+test("pre-reveal contribution summary omits local media locators", () => {
+  const contribution = seededDomainFixture.contributions[0];
+  const summary = toSafeContributionSummary(contribution);
+
+  assert.equal(summary.mediaKind, "photo");
+  assert.equal(summary.durationSeconds, 3);
+  assert.equal("localUri" in summary, false);
+  assert.equal("thumbnailUri" in summary, false);
+});

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "exactOptionalPropertyTypes": true,
+    "isolatedModules": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- add the framework-free `@rewind/domain` package;
- define V1 models for members, groups, cycles, contributions, messages, reactions, capsules, reminders, clocks, and audit events;
- encode contribution/cycle states, the approved photo/video media contract, and a pre-reveal-safe summary;
- add repository, clock, ID, transaction, and seed-reset ports without database/vendor implementations;
- add five-member synthetic fixtures and direct Node boundary tests;
- wire domain typechecking/tests into mobile checks and CI path triggers.

## Acceptance criteria

- [x] Domain code imports no React, React Native, Expo, SQLite, cloud SDK, or route module.
- [x] Types represent the V1 state machines and local-only limitations from the prototype spec.
- [x] Ports cover later commands/queries without exposing a database implementation.
- [x] Fixtures compile and a pure test runs outside the UI.

## Verification

- `make check` — PASS
- `npm run test -- --runInBand` from `apps/mobile/` — PASS (10 Node contract tests; 1 Jest/RNTL smoke test)
- `npm --prefix packages/domain test` — PASS (3 direct pure-domain tests)
- `npm --prefix packages/domain run typecheck` — PASS
- `npm run build:web` from `apps/mobile/` — PASS
- planning-document and package Prettier checks — PASS
- `git diff --check` — PASS

## Evidence

- [Completion note](https://github.com/Collaboration95/rewind-v1/blob/30a76773b4448e99be733dc2bad23a1c652bf753/evidence/issues/14/completion.md)
- [Domain implementation](https://github.com/Collaboration95/rewind-v1/tree/7b04bf9f969b70a135c6c5317c4490914db16540/packages/domain)

This contract slice requires no device, network, credential, or personal-media evidence.

Closes #14
