### PR TITLE
feat(storage): add local SQLite repository and seed

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -73,13 +73,22 @@ visual decisions are documented in the repository [`DESIGN.md`](../../DESIGN.md)
 and owned at runtime by `components/tokens.ts`.
 
 The workspace has two complementary test lanes. The dependency-free Node
-contract tests cover Router/config, tooling, and route/accessibility boundaries;
-the Jest + React Native Testing Library lane renders components under the
-Expo-compatible `jest-expo` preset. The framework-free `packages/domain/`
-package also runs a direct Node fixture and dependency-boundary test. `npm run
-test` runs all three lanes once and never starts watch mode. Use
-`npm run test:contracts`, `npm run test:domain`, or `npm run test:unit` to run
-one lane locally.
+contract tests cover Router/config, tooling, route/accessibility boundaries, and
+the real SQLite migration/seed/repository path; the Jest + React Native Testing
+Library lane renders components under the Expo-compatible `jest-expo` preset.
+The framework-free `packages/domain/` package also runs a direct Node fixture
+and dependency-boundary test. `npm run test` runs all three lanes once and
+never starts watch mode. Use `npm run test:contracts`, `npm run test:database`,
+`npm run test:domain`, or `npm run test:unit` to run one lane locally.
+
+## Local SQLite repository
+
+`data/local/` owns the device-local SQLite adapter. `openLocalDatabase()` opens
+`rewind-v1.db`, applies versioned migrations, and idempotently inserts the
+synthetic domain fixture. The returned repository implements the framework-free
+domain ports; `resetToSeed()` clears local records and restores that fixture.
+Only domain metadata and local media URIs are stored. The schema has no cloud
+credentials, remote media locators, blobs, or network client.
 
 ## Selector and accessibility contract
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -6,7 +6,7 @@
     "orientation": "portrait",
     "scheme": "rewind",
     "userInterfaceStyle": "dark",
-    "plugins": ["expo-router"],
+    "plugins": ["expo-router", "expo-sqlite"],
     "ios": {
       "bundleIdentifier": "com.rewind.v1"
     },

--- a/apps/mobile/data/local/database.ts
+++ b/apps/mobile/data/local/database.ts
@@ -1,0 +1,28 @@
+import { openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
+
+import { SQLiteDomainRepository } from './repository';
+import { DATABASE_NAME, migrateDatabase } from './schema';
+import { resetDatabaseToSeed, seedDatabase } from './seed';
+import { createExpoSqliteDriver } from './local-sqlite';
+
+export interface LocalDatabaseHandle {
+  readonly database: SQLiteDatabase;
+  readonly repository: SQLiteDomainRepository;
+  readonly resetToSeed: () => Promise<void>;
+}
+
+export async function openLocalDatabase(
+  databaseName: string = DATABASE_NAME,
+): Promise<LocalDatabaseHandle> {
+  const database = await openDatabaseAsync(databaseName);
+  const driver = createExpoSqliteDriver(database);
+
+  await migrateDatabase(driver);
+  await seedDatabase(driver);
+
+  return {
+    database,
+    repository: new SQLiteDomainRepository(driver),
+    resetToSeed: () => resetDatabaseToSeed(driver),
+  };
+}

--- a/apps/mobile/data/local/index.ts
+++ b/apps/mobile/data/local/index.ts
@@ -1,0 +1,15 @@
+export { openLocalDatabase, type LocalDatabaseHandle } from './database';
+export {
+  createExpoSqliteDriver,
+  type LocalSqliteDriver,
+  type LocalSqliteParam,
+} from './local-sqlite';
+export {
+  DATABASE_NAME,
+  LATEST_SCHEMA_VERSION,
+  MIGRATIONS,
+  migrateDatabase,
+  type Migration,
+} from './schema';
+export { resetDatabaseToSeed, seedDatabase } from './seed';
+export { SQLiteDomainRepository } from './repository';

--- a/apps/mobile/data/local/local-sqlite.ts
+++ b/apps/mobile/data/local/local-sqlite.ts
@@ -1,0 +1,24 @@
+import type { SQLiteBindValue, SQLiteDatabase, SQLiteRunResult } from 'expo-sqlite';
+
+export type LocalSqliteParam = SQLiteBindValue;
+
+export interface LocalSqliteDriver {
+  execAsync(source: string): Promise<void>;
+  getAllAsync<T>(source: string, params?: readonly LocalSqliteParam[]): Promise<T[]>;
+  getFirstAsync<T>(source: string, params?: readonly LocalSqliteParam[]): Promise<T | null>;
+  runAsync(source: string, params?: readonly LocalSqliteParam[]): Promise<SQLiteRunResult>;
+  withTransactionAsync(task: () => Promise<void>): Promise<void>;
+}
+
+export function createExpoSqliteDriver(database: SQLiteDatabase): LocalSqliteDriver {
+  const bind = (params: readonly LocalSqliteParam[] = []) => [...params] as SQLiteBindValue[];
+
+  return {
+    execAsync: (source: string) => database.execAsync(source),
+    getAllAsync: <T>(source: string, params = []) => database.getAllAsync<T>(source, bind(params)),
+    getFirstAsync: <T>(source: string, params = []) =>
+      database.getFirstAsync<T>(source, bind(params)),
+    runAsync: (source: string, params = []) => database.runAsync(source, bind(params)),
+    withTransactionAsync: (task) => database.withTransactionAsync(task),
+  };
+}

--- a/apps/mobile/data/local/repository.ts
+++ b/apps/mobile/data/local/repository.ts
@@ -1,0 +1,563 @@
+import type {
+  AuditEvent,
+  Capsule,
+  Contribution,
+  Cycle,
+  Group,
+  Member,
+  Message,
+  Reaction,
+  ReminderPreference,
+} from '../../../../packages/domain/src/models';
+import type {
+  AuditRepositoryPort,
+  CapsuleRepositoryPort,
+  ContributionRepositoryPort,
+  CycleRepositoryPort,
+  DomainRepositoryPort,
+  GroupRepositoryPort,
+  MemberRepositoryPort,
+  MessageRepositoryPort,
+  ReactionRepositoryPort,
+  ReminderRepositoryPort,
+} from '../../../../packages/domain/src/ports';
+
+import type { LocalSqliteDriver } from './local-sqlite';
+
+type MemberRow = {
+  avatar_seed: string;
+  display_name: string;
+  id: string;
+};
+
+type GroupRow = {
+  id: string;
+  name: string;
+  prompt: string;
+  timezone: string;
+};
+
+type GroupMemberRow = { member_id: string };
+
+type CycleRow = {
+  duration_seconds: number;
+  group_id: string;
+  id: string;
+  start_at: string;
+  status: Cycle['status'];
+};
+
+type ContributionRow = {
+  captured_at: string;
+  cycle_id: string;
+  deleted_at: string | null;
+  duration_seconds: number;
+  id: string;
+  local_uri: string | null;
+  media_kind: Contribution['mediaKind'];
+  member_id: string;
+  processing_attempt: number;
+  state: Contribution['state'];
+  vignette_treatment: Contribution['vignetteTreatment'];
+};
+
+type MessageRow = {
+  body: string;
+  created_at: string;
+  group_id: string;
+  id: string;
+  member_id: string;
+  reply_to_id: string | null;
+};
+
+type ReactionRow = {
+  emoji: string;
+  id: string;
+  member_id: string;
+  message_id: string;
+};
+
+type CapsuleRow = {
+  contribution_ids_json: string;
+  cycle_id: string;
+  id: string;
+  revealed_at: string | null;
+  status: Capsule['status'];
+};
+
+type ReminderRow = {
+  enabled: number;
+  hour: number;
+  member_id: string;
+  minute: number;
+  notification_id: string | null;
+  weekday: number;
+};
+
+type AuditRow = {
+  at: string;
+  id: string;
+  metadata_json: string;
+  subject_id: string;
+  type: string;
+};
+
+export class SQLiteDomainRepository implements DomainRepositoryPort {
+  private readonly database: LocalSqliteDriver;
+
+  public readonly audit: AuditRepositoryPort;
+  public readonly capsules: CapsuleRepositoryPort;
+  public readonly contributions: ContributionRepositoryPort;
+  public readonly cycles: CycleRepositoryPort;
+  public readonly groups: GroupRepositoryPort;
+  public readonly members: MemberRepositoryPort;
+  public readonly messages: MessageRepositoryPort;
+  public readonly reactions: ReactionRepositoryPort;
+  public readonly reminders: ReminderRepositoryPort;
+
+  public constructor(database: LocalSqliteDriver) {
+    this.database = database;
+    this.members = {
+      get: (memberId) => this.getMember(memberId),
+      listByGroup: (groupId) => this.listMembersByGroup(groupId),
+    };
+    this.groups = {
+      get: (groupId) => this.getGroup(groupId),
+    };
+    this.cycles = {
+      get: (cycleId) => this.getCycle(cycleId),
+      getCollecting: (groupId, at) => this.getCollectingCycle(groupId, at),
+      save: (cycle) => this.saveCycle(cycle),
+    };
+    this.contributions = {
+      get: (contributionId) => this.getContribution(contributionId),
+      listByCycle: (cycleId) => this.listContributionsByCycle(cycleId),
+      remove: (contributionId) => this.removeContribution(contributionId),
+      save: (contribution) => this.saveContribution(contribution),
+    };
+    this.messages = {
+      get: (messageId) => this.getMessage(messageId),
+      listByGroup: (groupId) => this.listMessagesByGroup(groupId),
+      save: (message) => this.saveMessage(message),
+    };
+    this.reactions = {
+      listByMessage: (messageId) => this.listReactionsByMessage(messageId),
+      remove: (reactionId) => this.removeReaction(reactionId),
+      save: (reaction) => this.saveReaction(reaction),
+    };
+    this.capsules = {
+      get: (capsuleId) => this.getCapsule(capsuleId),
+      getByCycle: (cycleId) => this.getCapsuleByCycle(cycleId),
+      save: (capsule) => this.saveCapsule(capsule),
+    };
+    this.reminders = {
+      get: (memberId) => this.getReminder(memberId),
+      save: (preference) => this.saveReminder(preference),
+    };
+    this.audit = {
+      append: (event) => this.appendAuditEvent(event),
+      list: (subjectId) => this.listAuditEvents(subjectId),
+    };
+  }
+
+  private async getMember(memberId: string): Promise<Member | null> {
+    const row = await this.database.getFirstAsync<MemberRow>(
+      'SELECT id, display_name, avatar_seed FROM members WHERE id = ?',
+      [memberId],
+    );
+    return row ? mapMember(row) : null;
+  }
+
+  private async listMembersByGroup(groupId: string): Promise<readonly Member[]> {
+    const rows = await this.database.getAllAsync<MemberRow>(
+      `SELECT m.id, m.display_name, m.avatar_seed
+       FROM members m
+       INNER JOIN group_members gm ON gm.member_id = m.id
+       WHERE gm.group_id = ?
+       ORDER BY m.id`,
+      [groupId],
+    );
+    return rows.map(mapMember);
+  }
+
+  private async getGroup(groupId: string): Promise<Group | null> {
+    const row = await this.database.getFirstAsync<GroupRow>(
+      'SELECT id, name, timezone, prompt FROM groups WHERE id = ?',
+      [groupId],
+    );
+    if (!row) {
+      return null;
+    }
+
+    const members = await this.database.getAllAsync<GroupMemberRow>(
+      'SELECT member_id FROM group_members WHERE group_id = ? ORDER BY member_id',
+      [groupId],
+    );
+    return {
+      id: row.id,
+      memberIds: members.map(({ member_id }) => member_id),
+      name: row.name,
+      prompt: row.prompt,
+      timezone: row.timezone,
+    };
+  }
+
+  private async getCycle(cycleId: string): Promise<Cycle | null> {
+    const row = await this.database.getFirstAsync<CycleRow>(
+      'SELECT id, group_id, start_at, duration_seconds, status FROM cycles WHERE id = ?',
+      [cycleId],
+    );
+    return row ? mapCycle(row) : null;
+  }
+
+  private async getCollectingCycle(groupId: string, at: string): Promise<Cycle | null> {
+    const row = await this.database.getFirstAsync<CycleRow>(
+      `SELECT id, group_id, start_at, duration_seconds, status
+       FROM cycles
+       WHERE group_id = ?
+         AND status = 'collecting'
+         AND start_at <= ?
+         AND datetime(start_at, '+' || duration_seconds || ' seconds') > datetime(?)
+       ORDER BY start_at DESC
+       LIMIT 1`,
+      [groupId, at, at],
+    );
+    return row ? mapCycle(row) : null;
+  }
+
+  private async saveCycle(cycle: Cycle): Promise<void> {
+    await this.database.runAsync(
+      `INSERT INTO cycles (id, group_id, start_at, duration_seconds, status)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         group_id = excluded.group_id,
+         start_at = excluded.start_at,
+         duration_seconds = excluded.duration_seconds,
+         status = excluded.status`,
+      [cycle.id, cycle.groupId, cycle.startAt, cycle.durationSeconds, cycle.status],
+    );
+  }
+
+  private async getContribution(contributionId: string): Promise<Contribution | null> {
+    const row = await this.database.getFirstAsync<ContributionRow>(
+      `SELECT id, cycle_id, member_id, captured_at, media_kind, duration_seconds,
+              vignette_treatment, local_uri, state, processing_attempt, deleted_at
+       FROM contributions WHERE id = ?`,
+      [contributionId],
+    );
+    return row ? mapContribution(row) : null;
+  }
+
+  private async listContributionsByCycle(cycleId: string): Promise<readonly Contribution[]> {
+    const rows = await this.database.getAllAsync<ContributionRow>(
+      `SELECT id, cycle_id, member_id, captured_at, media_kind, duration_seconds,
+              vignette_treatment, local_uri, state, processing_attempt, deleted_at
+       FROM contributions WHERE cycle_id = ? ORDER BY captured_at, id`,
+      [cycleId],
+    );
+    return rows.map(mapContribution);
+  }
+
+  private async saveContribution(contribution: Contribution): Promise<void> {
+    await this.database.runAsync(
+      `INSERT INTO contributions
+        (id, cycle_id, member_id, captured_at, media_kind, duration_seconds,
+         vignette_treatment, local_uri, state, processing_attempt, deleted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         cycle_id = excluded.cycle_id,
+         member_id = excluded.member_id,
+         captured_at = excluded.captured_at,
+         media_kind = excluded.media_kind,
+         duration_seconds = excluded.duration_seconds,
+         vignette_treatment = excluded.vignette_treatment,
+         local_uri = excluded.local_uri,
+         state = excluded.state,
+         processing_attempt = excluded.processing_attempt,
+         deleted_at = excluded.deleted_at`,
+      [
+        contribution.id,
+        contribution.cycleId,
+        contribution.memberId,
+        contribution.capturedAt,
+        contribution.mediaKind,
+        contribution.durationSeconds,
+        contribution.vignetteTreatment,
+        contribution.localUri,
+        contribution.state,
+        contribution.processingAttempt,
+        contribution.deletedAt,
+      ],
+    );
+  }
+
+  private async removeContribution(contributionId: string): Promise<void> {
+    await this.database.runAsync('DELETE FROM contributions WHERE id = ?', [contributionId]);
+  }
+
+  private async getMessage(messageId: string): Promise<Message | null> {
+    const row = await this.database.getFirstAsync<MessageRow>(
+      `SELECT id, group_id, member_id, body, reply_to_id, created_at
+       FROM messages WHERE id = ?`,
+      [messageId],
+    );
+    return row ? mapMessage(row) : null;
+  }
+
+  private async listMessagesByGroup(groupId: string): Promise<readonly Message[]> {
+    const rows = await this.database.getAllAsync<MessageRow>(
+      `SELECT id, group_id, member_id, body, reply_to_id, created_at
+       FROM messages WHERE group_id = ? ORDER BY created_at, id`,
+      [groupId],
+    );
+    return rows.map(mapMessage);
+  }
+
+  private async saveMessage(message: Message): Promise<void> {
+    await this.database.runAsync(
+      `INSERT INTO messages (id, group_id, member_id, body, reply_to_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         group_id = excluded.group_id,
+         member_id = excluded.member_id,
+         body = excluded.body,
+         reply_to_id = excluded.reply_to_id,
+         created_at = excluded.created_at`,
+      [
+        message.id,
+        message.groupId,
+        message.memberId,
+        message.body,
+        message.replyToId,
+        message.createdAt,
+      ],
+    );
+  }
+
+  private async listReactionsByMessage(messageId: string): Promise<readonly Reaction[]> {
+    const rows = await this.database.getAllAsync<ReactionRow>(
+      `SELECT id, message_id, member_id, emoji
+       FROM reactions WHERE message_id = ? ORDER BY id`,
+      [messageId],
+    );
+    return rows.map(mapReaction);
+  }
+
+  private async saveReaction(reaction: Reaction): Promise<void> {
+    await this.database.runAsync(
+      `INSERT INTO reactions (id, message_id, member_id, emoji)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         message_id = excluded.message_id,
+         member_id = excluded.member_id,
+         emoji = excluded.emoji`,
+      [reaction.id, reaction.messageId, reaction.memberId, reaction.emoji],
+    );
+  }
+
+  private async removeReaction(reactionId: string): Promise<void> {
+    await this.database.runAsync('DELETE FROM reactions WHERE id = ?', [reactionId]);
+  }
+
+  private async getCapsule(capsuleId: string): Promise<Capsule | null> {
+    const row = await this.database.getFirstAsync<CapsuleRow>(
+      `SELECT id, cycle_id, contribution_ids_json, status, revealed_at
+       FROM capsules WHERE id = ?`,
+      [capsuleId],
+    );
+    return row ? mapCapsule(row) : null;
+  }
+
+  private async getCapsuleByCycle(cycleId: string): Promise<Capsule | null> {
+    const row = await this.database.getFirstAsync<CapsuleRow>(
+      `SELECT id, cycle_id, contribution_ids_json, status, revealed_at
+       FROM capsules WHERE cycle_id = ?`,
+      [cycleId],
+    );
+    return row ? mapCapsule(row) : null;
+  }
+
+  private async saveCapsule(capsule: Capsule): Promise<void> {
+    await this.database.runAsync(
+      `INSERT INTO capsules
+        (id, cycle_id, contribution_ids_json, status, revealed_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         cycle_id = excluded.cycle_id,
+         contribution_ids_json = excluded.contribution_ids_json,
+         status = excluded.status,
+         revealed_at = excluded.revealed_at`,
+      [
+        capsule.id,
+        capsule.cycleId,
+        JSON.stringify(capsule.contributionIds),
+        capsule.status,
+        capsule.revealedAt,
+      ],
+    );
+  }
+
+  private async getReminder(memberId: string): Promise<ReminderPreference | null> {
+    const row = await this.database.getFirstAsync<ReminderRow>(
+      `SELECT member_id, enabled, weekday, hour, minute, notification_id
+       FROM reminder_preferences WHERE member_id = ?`,
+      [memberId],
+    );
+    return row ? mapReminder(row) : null;
+  }
+
+  private async saveReminder(preference: ReminderPreference): Promise<void> {
+    await this.database.runAsync(
+      `INSERT INTO reminder_preferences
+        (member_id, enabled, weekday, hour, minute, notification_id)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(member_id) DO UPDATE SET
+         enabled = excluded.enabled,
+         weekday = excluded.weekday,
+         hour = excluded.hour,
+         minute = excluded.minute,
+         notification_id = excluded.notification_id`,
+      [
+        preference.memberId,
+        preference.enabled ? 1 : 0,
+        preference.weekday,
+        preference.hour,
+        preference.minute,
+        preference.notificationId,
+      ],
+    );
+  }
+
+  private async appendAuditEvent(event: AuditEvent): Promise<void> {
+    await this.database.runAsync(
+      `INSERT INTO audit_events (id, type, at, subject_id, metadata_json)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         type = excluded.type,
+         at = excluded.at,
+         subject_id = excluded.subject_id,
+         metadata_json = excluded.metadata_json`,
+      [event.id, event.type, event.at, event.subjectId, JSON.stringify(event.metadata)],
+    );
+  }
+
+  private async listAuditEvents(subjectId?: string): Promise<readonly AuditEvent[]> {
+    const rows = subjectId
+      ? await this.database.getAllAsync<AuditRow>(
+          `SELECT id, type, at, subject_id, metadata_json
+           FROM audit_events WHERE subject_id = ? ORDER BY at, id`,
+          [subjectId],
+        )
+      : await this.database.getAllAsync<AuditRow>(
+          `SELECT id, type, at, subject_id, metadata_json
+           FROM audit_events ORDER BY at, id`,
+        );
+    return rows.map(mapAuditEvent);
+  }
+}
+
+function mapMember(row: MemberRow): Member {
+  return {
+    avatarSeed: row.avatar_seed,
+    displayName: row.display_name,
+    id: row.id,
+  };
+}
+
+function mapCycle(row: CycleRow): Cycle {
+  return {
+    durationSeconds: row.duration_seconds,
+    groupId: row.group_id,
+    id: row.id,
+    startAt: row.start_at,
+    status: row.status,
+  };
+}
+
+function mapContribution(row: ContributionRow): Contribution {
+  return {
+    capturedAt: row.captured_at,
+    cycleId: row.cycle_id,
+    deletedAt: row.deleted_at,
+    durationSeconds: row.duration_seconds,
+    id: row.id,
+    localUri: row.local_uri,
+    mediaKind: row.media_kind,
+    memberId: row.member_id,
+    processingAttempt: row.processing_attempt,
+    state: row.state,
+    vignetteTreatment: row.vignette_treatment,
+  };
+}
+
+function mapMessage(row: MessageRow): Message {
+  return {
+    body: row.body,
+    createdAt: row.created_at,
+    groupId: row.group_id,
+    id: row.id,
+    memberId: row.member_id,
+    replyToId: row.reply_to_id,
+  };
+}
+
+function mapReaction(row: ReactionRow): Reaction {
+  return {
+    emoji: row.emoji,
+    id: row.id,
+    memberId: row.member_id,
+    messageId: row.message_id,
+  };
+}
+
+function mapCapsule(row: CapsuleRow): Capsule {
+  return {
+    contributionIds: parseStringArray(row.contribution_ids_json),
+    cycleId: row.cycle_id,
+    id: row.id,
+    revealedAt: row.revealed_at,
+    status: row.status,
+  };
+}
+
+function mapReminder(row: ReminderRow): ReminderPreference {
+  return {
+    enabled: row.enabled === 1,
+    hour: row.hour,
+    memberId: row.member_id,
+    minute: row.minute,
+    notificationId: row.notification_id,
+    weekday: row.weekday,
+  };
+}
+
+function mapAuditEvent(row: AuditRow): AuditEvent {
+  return {
+    at: row.at,
+    id: row.id,
+    metadata: parseMetadata(row.metadata_json),
+    subjectId: row.subject_id,
+    type: row.type,
+  };
+}
+
+function parseStringArray(value: string): readonly string[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) && parsed.every((item) => typeof item === 'string') ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseMetadata(value: string): Readonly<Record<string, string | number | boolean | null>> {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, string | number | boolean | null>;
+    }
+  } catch {
+    // Malformed metadata should not prevent local records from being read.
+  }
+  return {};
+}

--- a/apps/mobile/data/local/schema.ts
+++ b/apps/mobile/data/local/schema.ts
@@ -1,0 +1,141 @@
+import type { LocalSqliteDriver } from './local-sqlite';
+
+export const DATABASE_NAME = 'rewind-v1.db';
+export const LATEST_SCHEMA_VERSION = 1;
+
+export interface Migration {
+  readonly version: number;
+  readonly statements: readonly string[];
+}
+
+export const MIGRATIONS: readonly Migration[] = [
+  {
+    version: 1,
+    statements: [
+      `
+        CREATE TABLE IF NOT EXISTS members (
+          id TEXT PRIMARY KEY NOT NULL,
+          display_name TEXT NOT NULL,
+          avatar_seed TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS groups (
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT NOT NULL,
+          timezone TEXT NOT NULL,
+          prompt TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS group_members (
+          group_id TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+          member_id TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+          PRIMARY KEY (group_id, member_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS cycles (
+          id TEXT PRIMARY KEY NOT NULL,
+          group_id TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+          start_at TEXT NOT NULL,
+          duration_seconds INTEGER NOT NULL,
+          status TEXT NOT NULL CHECK (status IN ('collecting', 'reveal_pending', 'premiere', 'delayed', 'archived'))
+        );
+
+        CREATE TABLE IF NOT EXISTS contributions (
+          id TEXT PRIMARY KEY NOT NULL,
+          cycle_id TEXT NOT NULL REFERENCES cycles(id) ON DELETE CASCADE,
+          member_id TEXT NOT NULL REFERENCES members(id) ON DELETE RESTRICT,
+          captured_at TEXT NOT NULL,
+          media_kind TEXT NOT NULL CHECK (media_kind IN ('photo', 'video')),
+          duration_seconds REAL NOT NULL,
+          vignette_treatment TEXT NOT NULL CHECK (vignette_treatment IN ('flash', 'ccd', 'home-movie', 'tape')),
+          local_uri TEXT,
+          state TEXT NOT NULL CHECK (state IN ('recording', 'captured', 'processing', 'locked', 'failed', 'revealed', 'archived', 'deleted')),
+          processing_attempt INTEGER NOT NULL DEFAULT 0,
+          deleted_at TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS messages (
+          id TEXT PRIMARY KEY NOT NULL,
+          group_id TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+          member_id TEXT NOT NULL REFERENCES members(id) ON DELETE RESTRICT,
+          body TEXT NOT NULL,
+          reply_to_id TEXT REFERENCES messages(id) ON DELETE SET NULL,
+          created_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS reactions (
+          id TEXT PRIMARY KEY NOT NULL,
+          message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+          member_id TEXT NOT NULL REFERENCES members(id) ON DELETE RESTRICT,
+          emoji TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS capsules (
+          id TEXT PRIMARY KEY NOT NULL,
+          cycle_id TEXT NOT NULL REFERENCES cycles(id) ON DELETE CASCADE,
+          contribution_ids_json TEXT NOT NULL,
+          status TEXT NOT NULL CHECK (status IN ('premiere', 'archived')),
+          revealed_at TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS reminder_preferences (
+          member_id TEXT PRIMARY KEY NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+          enabled INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+          weekday INTEGER NOT NULL,
+          hour INTEGER NOT NULL,
+          minute INTEGER NOT NULL,
+          notification_id TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS simulation_clock (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          now TEXT NOT NULL,
+          mode TEXT NOT NULL CHECK (mode IN ('real', 'demo-minute', 'demo-day', 'demo-cycle'))
+        );
+
+        CREATE TABLE IF NOT EXISTS audit_events (
+          id TEXT PRIMARY KEY NOT NULL,
+          type TEXT NOT NULL,
+          at TEXT NOT NULL,
+          subject_id TEXT NOT NULL,
+          metadata_json TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_group_members_member ON group_members(member_id);
+        CREATE INDEX IF NOT EXISTS idx_cycles_group_status ON cycles(group_id, status);
+        CREATE INDEX IF NOT EXISTS idx_contributions_cycle_captured ON contributions(cycle_id, captured_at);
+        CREATE INDEX IF NOT EXISTS idx_messages_group_created ON messages(group_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id);
+        CREATE INDEX IF NOT EXISTS idx_audit_subject_at ON audit_events(subject_id, at);
+      `,
+    ],
+  },
+];
+
+export async function migrateDatabase(database: LocalSqliteDriver): Promise<void> {
+  await database.execAsync('PRAGMA foreign_keys = ON;');
+
+  const currentVersionRow = await database.getFirstAsync<{ user_version: number }>(
+    'PRAGMA user_version',
+  );
+  const currentVersion = Number(currentVersionRow?.user_version ?? 0);
+
+  if (!Number.isInteger(currentVersion) || currentVersion < 0) {
+    throw new Error('SQLite schema version is invalid');
+  }
+
+  if (currentVersion > LATEST_SCHEMA_VERSION) {
+    throw new Error(
+      `SQLite schema version ${currentVersion} is newer than supported version ${LATEST_SCHEMA_VERSION}`,
+    );
+  }
+
+  for (const migration of MIGRATIONS.filter(({ version }) => version > currentVersion)) {
+    await database.withTransactionAsync(async () => {
+      for (const statement of migration.statements) {
+        await database.execAsync(statement);
+      }
+      await database.execAsync(`PRAGMA user_version = ${migration.version};`);
+    });
+  }
+}

--- a/apps/mobile/data/local/seed.ts
+++ b/apps/mobile/data/local/seed.ts
@@ -1,0 +1,145 @@
+import {
+  seededDomainFixture,
+  type DomainFixture,
+} from '../../../../packages/domain/src/fixtures.ts';
+
+import type { LocalSqliteDriver } from './local-sqlite';
+
+export async function seedDatabase(
+  database: LocalSqliteDriver,
+  fixture: DomainFixture = seededDomainFixture,
+): Promise<void> {
+  await database.withTransactionAsync(() => insertFixture(database, fixture));
+}
+
+async function insertFixture(database: LocalSqliteDriver, fixture: DomainFixture): Promise<void> {
+  for (const member of fixture.members) {
+    await database.runAsync(
+      'INSERT OR IGNORE INTO members (id, display_name, avatar_seed) VALUES (?, ?, ?)',
+      [member.id, member.displayName, member.avatarSeed],
+    );
+  }
+
+  await database.runAsync(
+    'INSERT OR IGNORE INTO groups (id, name, timezone, prompt) VALUES (?, ?, ?, ?)',
+    [fixture.group.id, fixture.group.name, fixture.group.timezone, fixture.group.prompt],
+  );
+
+  for (const memberId of fixture.group.memberIds) {
+    await database.runAsync(
+      'INSERT OR IGNORE INTO group_members (group_id, member_id) VALUES (?, ?)',
+      [fixture.group.id, memberId],
+    );
+  }
+
+  await database.runAsync(
+    'INSERT OR IGNORE INTO cycles (id, group_id, start_at, duration_seconds, status) VALUES (?, ?, ?, ?, ?)',
+    [
+      fixture.cycle.id,
+      fixture.cycle.groupId,
+      fixture.cycle.startAt,
+      fixture.cycle.durationSeconds,
+      fixture.cycle.status,
+    ],
+  );
+
+  for (const contribution of fixture.contributions) {
+    await database.runAsync(
+      `INSERT OR IGNORE INTO contributions
+        (id, cycle_id, member_id, captured_at, media_kind, duration_seconds,
+         vignette_treatment, local_uri, state, processing_attempt, deleted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        contribution.id,
+        contribution.cycleId,
+        contribution.memberId,
+        contribution.capturedAt,
+        contribution.mediaKind,
+        contribution.durationSeconds,
+        contribution.vignetteTreatment,
+        contribution.localUri,
+        contribution.state,
+        contribution.processingAttempt,
+        contribution.deletedAt,
+      ],
+    );
+  }
+
+  for (const message of fixture.messages) {
+    await database.runAsync(
+      'INSERT OR IGNORE INTO messages (id, group_id, member_id, body, reply_to_id, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+      [
+        message.id,
+        message.groupId,
+        message.memberId,
+        message.body,
+        message.replyToId,
+        message.createdAt,
+      ],
+    );
+  }
+
+  for (const reaction of fixture.reactions) {
+    await database.runAsync(
+      'INSERT OR IGNORE INTO reactions (id, message_id, member_id, emoji) VALUES (?, ?, ?, ?)',
+      [reaction.id, reaction.messageId, reaction.memberId, reaction.emoji],
+    );
+  }
+
+  await database.runAsync(
+    'INSERT OR IGNORE INTO capsules (id, cycle_id, contribution_ids_json, status, revealed_at) VALUES (?, ?, ?, ?, ?)',
+    [
+      fixture.capsule.id,
+      fixture.capsule.cycleId,
+      JSON.stringify(fixture.capsule.contributionIds),
+      fixture.capsule.status,
+      fixture.capsule.revealedAt,
+    ],
+  );
+
+  await database.runAsync(
+    'INSERT OR IGNORE INTO reminder_preferences (member_id, enabled, weekday, hour, minute, notification_id) VALUES (?, ?, ?, ?, ?, ?)',
+    [
+      fixture.reminder.memberId,
+      fixture.reminder.enabled ? 1 : 0,
+      fixture.reminder.weekday,
+      fixture.reminder.hour,
+      fixture.reminder.minute,
+      fixture.reminder.notificationId,
+    ],
+  );
+
+  await database.runAsync(
+    'INSERT OR IGNORE INTO simulation_clock (id, now, mode) VALUES (1, ?, ?)',
+    [fixture.clock.now, fixture.clock.mode],
+  );
+
+  for (const event of fixture.auditEvents) {
+    await database.runAsync(
+      'INSERT OR IGNORE INTO audit_events (id, type, at, subject_id, metadata_json) VALUES (?, ?, ?, ?, ?)',
+      [event.id, event.type, event.at, event.subjectId, JSON.stringify(event.metadata)],
+    );
+  }
+}
+
+export async function resetDatabaseToSeed(
+  database: LocalSqliteDriver,
+  fixture: DomainFixture = seededDomainFixture,
+): Promise<void> {
+  await database.withTransactionAsync(async () => {
+    await database.execAsync(`
+      DELETE FROM audit_events;
+      DELETE FROM reactions;
+      DELETE FROM messages;
+      DELETE FROM contributions;
+      DELETE FROM capsules;
+      DELETE FROM reminder_preferences;
+      DELETE FROM group_members;
+      DELETE FROM cycles;
+      DELETE FROM groups;
+      DELETE FROM members;
+      DELETE FROM simulation_clock;
+    `);
+    await insertFixture(database, fixture);
+  });
+}

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,0 +1,13 @@
+const path = require('node:path');
+const { getDefaultConfig } = require('expo/metro-config');
+
+const projectRoot = __dirname;
+const domainRoot = path.resolve(projectRoot, '../../packages/domain');
+const config = getDefaultConfig(projectRoot);
+
+// The local adapter reuses the framework-free domain fixture and types. Keep
+// that package outside the app bundle while explicitly making it resolvable by
+// Metro; no other workspace directory is made available to the client bundle.
+config.watchFolders = [domainRoot];
+
+module.exports = config;

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -14,6 +14,7 @@
         "expo-linking": "~57.0.8",
         "expo-router": "~57.0.17",
         "expo-splash-screen": "~57.0.8",
+        "expo-sqlite": "~57.0.2",
         "expo-status-bar": "~57.0.1",
         "expo-system-ui": "~57.0.3",
         "react": "19.2.3",
@@ -4906,6 +4907,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -7356,6 +7363,20 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-57.0.2.tgz",
+      "integrity": "sha512-5KVbT7BQFZlIcQBXKWvwBERK3ODF6PSqct27GQKukZzAjsx2B97R+mwtYqrTUtUbw71VJrQrdr9Yl2OWYC7UpA==",
+      "license": "MIT",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,6 +10,7 @@
     "expo-linking": "~57.0.8",
     "expo-router": "~57.0.17",
     "expo-splash-screen": "~57.0.8",
+    "expo-sqlite": "~57.0.2",
     "expo-status-bar": "~57.0.1",
     "expo-system-ui": "~57.0.3",
     "react": "19.2.3",
@@ -51,6 +52,7 @@
     "typecheck:domain": "npm --prefix ../../packages/domain run typecheck",
     "test": "node scripts/test.cjs && jest --runInBand",
     "test:contracts": "node scripts/test.cjs",
+    "test:database": "node --experimental-strip-types --test tests/local-database.test.mjs",
     "test:domain": "node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs",
     "test:unit": "jest --runInBand",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm run test"

--- a/apps/mobile/scripts/test.cjs
+++ b/apps/mobile/scripts/test.cjs
@@ -12,6 +12,7 @@ const result = spawnSync(
     'tests/tooling.test.mjs',
     'tests/routes.test.mjs',
     'tests/media-contract.test.mjs',
+    'tests/local-database.test.mjs',
     '../../packages/domain/tests/domain.test.mjs',
     '../../packages/domain/tests/boundary.test.mjs',
   ],

--- a/apps/mobile/tests/local-database.test.mjs
+++ b/apps/mobile/tests/local-database.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { SQLiteDomainRepository } from '../data/local/repository.ts';
+import { migrateDatabase } from '../data/local/schema.ts';
+import { resetDatabaseToSeed, seedDatabase } from '../data/local/seed.ts';
+
+class NodeSqliteDriver {
+  constructor(databasePath) {
+    this.database = new DatabaseSync(databasePath);
+  }
+
+  async execAsync(source) {
+    this.database.exec(source);
+  }
+
+  async getAllAsync(source, params = []) {
+    return this.database.prepare(source).all(...params);
+  }
+
+  async getFirstAsync(source, params = []) {
+    return this.database.prepare(source).get(...params) ?? null;
+  }
+
+  async runAsync(source, params = []) {
+    const result = this.database.prepare(source).run(...params);
+    return {
+      changes: Number(result.changes),
+      lastInsertRowId: Number(result.lastInsertRowid),
+    };
+  }
+
+  async withTransactionAsync(task) {
+    this.database.exec('BEGIN');
+    try {
+      await task();
+      this.database.exec('COMMIT');
+    } catch (error) {
+      this.database.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  close() {
+    this.database.close();
+  }
+}
+
+test('migrations, seed, repository reads, relaunch, and reset use real SQLite', async () => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'rewind-v1-'));
+  const databasePath = join(temporaryDirectory, 'rewind-v1.db');
+  let driver = new NodeSqliteDriver(databasePath);
+
+  try {
+    await migrateDatabase(driver);
+    await seedDatabase(driver);
+
+    assert.equal(Number((await driver.getFirstAsync('PRAGMA user_version'))?.user_version), 1);
+    assert.equal(Number((await driver.getFirstAsync('PRAGMA foreign_keys'))?.foreign_keys), 1);
+
+    const repository = new SQLiteDomainRepository(driver);
+    const group = await repository.groups.get('group-rewind-demo');
+    const members = await repository.members.listByGroup('group-rewind-demo');
+    const cycle = await repository.cycles.get('cycle-rewind-demo');
+    const collectingCycle = await repository.cycles.getCollecting(
+      'group-rewind-demo',
+      '2026-08-30T10:00:00.000Z',
+    );
+    const contributions = await repository.contributions.listByCycle('cycle-rewind-demo');
+    const messages = await repository.messages.listByGroup('group-rewind-demo');
+    const capsule = await repository.capsules.getByCycle('cycle-rewind-demo');
+    const reminder = await repository.reminders.get('member-ava');
+
+    assert.equal(group?.name, 'The Sunday Room');
+    assert.equal(members.length, 5);
+    assert.ok(cycle);
+    assert.equal(cycle?.status, 'collecting');
+    assert.equal(collectingCycle?.id, 'cycle-rewind-demo');
+    assert.deepEqual(
+      contributions.map(({ mediaKind, durationSeconds }) => ({ mediaKind, durationSeconds })),
+      [
+        { mediaKind: 'photo', durationSeconds: 3 },
+        { mediaKind: 'video', durationSeconds: 5 },
+      ],
+    );
+    assert.equal(messages[0]?.body, 'The light after rain counts.');
+    assert.deepEqual(capsule?.contributionIds, [
+      'contribution-photo-demo',
+      'contribution-video-demo',
+    ]);
+    assert.equal(reminder?.enabled, false);
+
+    for (const [table, expectedCount] of [
+      ['members', 5],
+      ['groups', 1],
+      ['group_members', 5],
+      ['cycles', 1],
+      ['contributions', 2],
+      ['messages', 1],
+      ['capsules', 1],
+      ['reminder_preferences', 1],
+      ['simulation_clock', 1],
+      ['audit_events', 0],
+    ]) {
+      const row = await driver.getFirstAsync(`SELECT COUNT(*) AS count FROM ${table}`);
+      assert.equal(Number(row?.count), expectedCount, `seed count for ${table}`);
+    }
+
+    await repository.cycles.save({ ...cycle, status: 'reveal_pending' });
+    assert.equal((await repository.contributions.listByCycle('cycle-rewind-demo')).length, 2);
+
+    await repository.audit.append({
+      id: 'audit-local-edit',
+      type: 'local.test',
+      at: '2026-08-30T10:30:00.000Z',
+      subjectId: 'group-rewind-demo',
+      metadata: { source: 'test' },
+    });
+    assert.equal((await repository.audit.list('group-rewind-demo')).length, 1);
+
+    await driver.runAsync(
+      'INSERT INTO messages (id, group_id, member_id, body, reply_to_id, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+      [
+        'message-local-edit',
+        'group-rewind-demo',
+        'member-ava',
+        'A persisted local note.',
+        null,
+        '2026-08-30T11:00:00.000Z',
+      ],
+    );
+
+    // A close/reopen on the same file exercises actual relaunch persistence.
+    driver.close();
+    driver = new NodeSqliteDriver(databasePath);
+    await migrateDatabase(driver);
+    await seedDatabase(driver);
+    const relaunchedRepository = new SQLiteDomainRepository(driver);
+    assert.equal((await relaunchedRepository.messages.listByGroup('group-rewind-demo')).length, 2);
+    assert.equal((await relaunchedRepository.audit.list('group-rewind-demo')).length, 1);
+    assert.equal(
+      (await relaunchedRepository.cycles.get('cycle-rewind-demo'))?.status,
+      'reveal_pending',
+    );
+
+    await resetDatabaseToSeed(driver);
+    assert.equal((await relaunchedRepository.messages.listByGroup('group-rewind-demo')).length, 1);
+    assert.equal((await relaunchedRepository.members.listByGroup('group-rewind-demo')).length, 5);
+    assert.equal((await relaunchedRepository.audit.list('group-rewind-demo')).length, 0);
+    assert.equal(
+      (await relaunchedRepository.cycles.get('cycle-rewind-demo'))?.status,
+      'collecting',
+    );
+  } finally {
+    driver.close();
+    rmSync(temporaryDirectory, { force: true, recursive: true });
+  }
+});
+
+test('schema has no blob, credential, or remote-media columns', async () => {
+  const driver = new NodeSqliteDriver(':memory:');
+  try {
+    await migrateDatabase(driver);
+
+    const rows = await driver.getAllAsync(
+      `SELECT name, sql FROM sqlite_master
+       WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+       ORDER BY name`,
+    );
+    const schema = rows.map(({ name, sql }) => `${name} ${sql}`).join('\n');
+
+    assert.doesNotMatch(schema, /blob|password|token|secret|credential|remote|https?:\/\//i);
+    assert.match(schema, /local_uri TEXT/);
+    assert.match(schema, /metadata_json TEXT/);
+  } finally {
+    driver.close();
+  }
+});

--- a/apps/mobile/tests/tooling.test.mjs
+++ b/apps/mobile/tests/tooling.test.mjs
@@ -8,6 +8,7 @@ const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = resolve(appRoot, '../..');
 const packageManifest = JSON.parse(readFileSync(join(appRoot, 'package.json'), 'utf8'));
 const jestConfig = readFileSync(join(appRoot, 'jest.config.cjs'), 'utf8');
+const metroConfig = readFileSync(join(appRoot, 'metro.config.js'), 'utf8');
 const domainManifest = JSON.parse(
   readFileSync(join(repoRoot, 'packages/domain/package.json'), 'utf8'),
 );
@@ -30,6 +31,10 @@ test('mobile quality scripts are deterministic and non-watch', () => {
   assert.match(scripts.test, /^node scripts\/test\.cjs && jest --runInBand$/);
   assert.equal(scripts['test:contracts'], 'node scripts/test.cjs');
   assert.equal(
+    scripts['test:database'],
+    'node --experimental-strip-types --test tests/local-database.test.mjs',
+  );
+  assert.equal(
     scripts['test:domain'],
     'node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs',
   );
@@ -47,6 +52,8 @@ test('mobile quality scripts are deterministic and non-watch', () => {
   assert.match(jestConfig, /preset: 'jest-expo'/);
   assert.match(jestConfig, /setupFilesAfterEnv: \['<rootDir>\/tests\/setup\.ts'\]/);
   assert.match(jestConfig, /tests\/\*\*\/\*\.test\.tsx/);
+  assert.match(metroConfig, /packages\/domain/);
+  assert.match(metroConfig, /watchFolders/);
   assert.match(scripts.check, /format:check/);
   assert.match(scripts.check, /lint/);
   assert.match(scripts.check, /typecheck/);

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "strict": true
   },
   "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]

--- a/evidence/issues/15/completion.md
+++ b/evidence/issues/15/completion.md
@@ -1,0 +1,51 @@
+# Issue 15 completion evidence
+
+- Issue: [#15 — Implement SQLite migrations, seed fixtures, and resettable local repository](https://github.com/Collaboration95/rewind-v1/issues/15)
+- Branch: `codex/15-local-sqlite-seed-repository`
+- Implementation commit: [ebb0ef1](https://github.com/Collaboration95/rewind-v1/commit/ebb0ef14e71d094e3852e73748964354eef91863)
+
+## Scope delivered
+
+Added a versioned Expo SQLite schema and migration runner, a deterministic
+five-member `The Sunday Room` seed, an atomic reset-to-seed command, and a
+SQLite-backed adapter implementing the framework-free domain repository ports.
+The adapter persists group/profile/cycle/contribution/chat/reaction/capsule,
+reminder, and audit metadata. Contribution rows contain only local media URIs;
+the schema has no media blobs, cloud credentials, or remote media locators.
+
+The mobile Metro config explicitly resolves only `packages/domain/`, which lets
+the app reuse the shared fixture without turning the repository root into an
+Expo workspace. Repository updates use conflict clauses rather than replace
+operations, so updating a cycle or message cannot cascade-delete related rows.
+
+## Verification
+
+- `make check` — PASS (workflow YAML validation, Prettier, ESLint, app and domain TypeScript checks, 12 Node contract tests, and one Jest/RNTL smoke test).
+- `npm run test:database` from `apps/mobile/` — PASS (two real SQLite tests).
+- `npm run build:web` from `apps/mobile/` — PASS (Expo web export).
+- Temporary Metro resolution probe — PASS: importing the shared domain fixture from a route bundled successfully; the probe import was removed before the implementation commit.
+- `git diff --check` — PASS.
+
+The SQLite test uses a temporary on-disk database, verifies schema version and
+foreign-key enforcement, seeds exact table counts, closes and reopens the same
+file, confirms local records survive relaunch, and verifies that the atomic
+reset restores the deterministic seed.
+
+Relevant output:
+
+```text
+✔ migrations, seed, repository reads, relaunch, and reset use real SQLite
+✔ schema has no blob, credential, or remote-media columns
+ℹ tests 2
+ℹ pass 2
+ℹ fail 0
+```
+
+## Device and privacy limitations
+
+This ticket is a data-layer slice and does not add a visible route consumer, so
+no simulator screenshot or device persistence claim is made. The on-disk SQLite
+verification uses only synthetic names and `file:///synthetic/` URIs. A later
+profile/capture route will exercise the Expo adapter on a simulator or supported
+device; no personal media, network service, cloud credential, or build output
+was used.

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -5,8 +5,9 @@ view types, repository ports, deterministic fixtures, and time/transaction
 capabilities. It must not import React Native, Expo, SQLite, cloud SDKs, route
 modules, or vendor-specific clients.
 
-The package is intentionally implementation-free in this slice. Local SQLite,
-device, and policy adapters implement these ports in later issues.
+The package remains implementation-free. The device-local SQLite adapter in
+`apps/mobile/data/local/` implements these ports without adding persistence or
+vendor dependencies to this package.
 
 Run its checks from the repository root:
 
@@ -16,5 +17,8 @@ npm --prefix packages/domain test
 ```
 
 The pure test runs with Node's TypeScript type stripping and imports no UI. The
-synthetic fixture includes both a photo and a video so the approved media
-contract stays visible at the domain boundary.
+synthetic fixture is the deterministic `The Sunday Room` group with Ava, Ben,
+Cleo, Dev, and Finn; the prompt `What deserves a frame this week?`; one
+collecting cycle; one locked three-second photo; one locked five-second video;
+one chat message; and a demo-cycle clock. It includes both media kinds so the
+approved local media contract stays visible at the domain boundary.


### PR DESCRIPTION
## Summary\n\n- add versioned Expo SQLite migrations and deterministic five-member seed\n- implement the local repository adapter for the framework-free domain ports\n- preserve on-disk records across reopen and provide an atomic reset-to-seed command\n- verify metadata/local-URI-only schema and Metro domain-package resolution\n\n## Verification\n\n- `make check`\n- `npm run test:database` from `apps/mobile/`\n- `npm run build:web` from `apps/mobile/`\n\nAll pass with synthetic fixtures. See [issue 15 evidence](https://github.com/Collaboration95/rewind-v1/blob/main/evidence/issues/15/completion.md).\n\nCloses #15