### PR TITLE
feat(domain): enforce contribution lifecycle policy

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -53,7 +53,7 @@
     "test": "node scripts/test.cjs && jest --runInBand",
     "test:contracts": "node scripts/test.cjs",
     "test:database": "node --experimental-strip-types --test tests/local-database.test.mjs",
-    "test:domain": "node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs",
+    "test:domain": "node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs ../../packages/domain/tests/policy.test.mjs",
     "test:unit": "jest --runInBand",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm run test"
   }

--- a/apps/mobile/scripts/test.cjs
+++ b/apps/mobile/scripts/test.cjs
@@ -15,6 +15,7 @@ const result = spawnSync(
     'tests/local-database.test.mjs',
     '../../packages/domain/tests/domain.test.mjs',
     '../../packages/domain/tests/boundary.test.mjs',
+    '../../packages/domain/tests/policy.test.mjs',
   ],
   { stdio: 'inherit' },
 );

--- a/apps/mobile/tests/tooling.test.mjs
+++ b/apps/mobile/tests/tooling.test.mjs
@@ -36,7 +36,7 @@ test('mobile quality scripts are deterministic and non-watch', () => {
   );
   assert.equal(
     scripts['test:domain'],
-    'node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs',
+    'node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs ../../packages/domain/tests/policy.test.mjs',
   );
   assert.equal(scripts['test:unit'], 'jest --runInBand');
 
@@ -46,7 +46,7 @@ test('mobile quality scripts are deterministic and non-watch', () => {
   );
   assert.equal(
     domainManifest.scripts.test,
-    'node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs',
+    'node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs tests/policy.test.mjs',
   );
 
   assert.match(jestConfig, /preset: 'jest-expo'/);

--- a/evidence/issues/16/completion.md
+++ b/evidence/issues/16/completion.md
@@ -1,0 +1,54 @@
+# Issue 16 completion evidence
+
+- Issue: [#16 — Implement contribution budget and lifecycle policy state machine](https://github.com/Collaboration95/rewind-v1/issues/16)
+- Branch: `codex/16-contribution-policy`
+- Implementation commit: [eec0016](https://github.com/Collaboration95/rewind-v1/commit/eec0016e880a99244fabd9c440b0a2829d9b09e3)
+
+## Scope delivered
+
+Added a framework-free contribution policy under `packages/domain/src/policy/`.
+Capture validation enforces local membership, collecting-cycle state, photo
+three-second duration, video 1–15-second duration, five active slots, and a
+30-second per-member/cycle budget. Deleted contributions no longer consume
+quota, allowing the one permitted retake.
+
+Processing transitions are explicit (`captured → processing → locked`), with a
+bounded single retry, failure state, idempotent duplicate starts/completions,
+and no operation that creates a second locked contribution. Deletion requires
+the contributing member, is blocked after reveal, and accepts a normalized
+simulated-week key from the time adapter. Accepted delete audit metadata can be
+rehydrated after relaunch; policy rejections always include a user-safe reason
+and an audit event.
+
+Pre-reveal summaries are sorted deterministic metadata views and omit local
+URI, thumbnail, player-source, and other media locators.
+
+## Verification
+
+- `npm --prefix packages/domain test` — PASS (7 direct domain tests).
+- `npm --prefix packages/domain run typecheck` — PASS.
+- `make check` — PASS (workflow validation, formatting, lint, app/domain typechecks, 16 Node contract tests, and one Jest/RNTL smoke test).
+- `npm --prefix apps/mobile run build:web` — PASS (Expo web export).
+- `git diff --check` — PASS.
+
+Relevant output:
+
+```text
+ℹ tests 7
+ℹ pass 7
+ℹ fail 0
+```
+
+The policy tests cover the 1-second and 15-second video boundaries, fixed
+photo duration, fifth-slot and 30-second boundaries, membership and duplicate
+rejections, quota restoration, same-week delete rejection without mutation,
+retry exhaustion, idempotent lock behavior, audit-event rehydration, and
+pre-reveal locator privacy.
+
+## Device and product-decision limitations
+
+This ticket is pure domain logic and intentionally adds no route or device
+operation, so no simulator screenshot or camera/permission claim is made. The
+week key is supplied by a future clock/time adapter rather than inferred here;
+this keeps timezone and DST policy explicit for the simulation ticket. All test
+data is synthetic and local-first.

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -22,3 +22,15 @@ Cleo, Dev, and Finn; the prompt `What deserves a frame this week?`; one
 collecting cycle; one locked three-second photo; one locked five-second video;
 one chat message; and a demo-cycle clock. It includes both media kinds so the
 approved local media contract stays visible at the domain boundary.
+
+## Contribution policy
+
+`src/policy/` contains pure commands for capture validation, processing and
+retry transitions, one-delete quota restoration, and lock-safe pre-reveal
+summaries. The policy accepts an injected normalized simulated-week key and
+audit-event ID; it does not calculate timezone/DST boundaries or perform device
+I/O. Rejections always include a user-safe reason and an audit event. Delete
+audits carry the normalized week key and can be rehydrated after relaunch. V1
+allows five contributions and 30 total seconds per member/cycle, fixed
+three-second photos, 1–15 second videos, one retry, and one delete per
+simulated week.

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -8,6 +8,6 @@
   },
   "scripts": {
     "typecheck": "../../apps/mobile/node_modules/.bin/tsc --noEmit -p tsconfig.json",
-    "test": "node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs"
+    "test": "node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs tests/policy.test.mjs"
   }
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./fixtures.ts";
 export * from "./models.ts";
+export * from "./policy/index.ts";
 export * from "./ports.ts";

--- a/packages/domain/src/policy/contribution-policy.ts
+++ b/packages/domain/src/policy/contribution-policy.ts
@@ -1,0 +1,728 @@
+import type {
+  AuditEvent,
+  AuditEventId,
+  Contribution,
+  ContributionId,
+  Cycle,
+  CycleId,
+  Group,
+  IsoTimestamp,
+  MediaKind,
+  MemberId,
+  SafeContributionSummary,
+  VignetteTreatment,
+} from "../models.ts";
+import {
+  MEDIA_KINDS,
+  toSafeContributionSummary,
+  VIGNETTE_TREATMENTS,
+} from "../models.ts";
+
+export const MAX_CONTRIBUTIONS_PER_MEMBER = 5;
+export const MAX_TOTAL_DURATION_SECONDS = 30;
+export const MIN_VIDEO_DURATION_SECONDS = 1;
+export const MAX_VIDEO_DURATION_SECONDS = 15;
+export const PHOTO_DURATION_SECONDS = 3;
+export const MAX_PROCESSING_ATTEMPTS = 2;
+export const MAX_DELETIONS_PER_WEEK = 1;
+
+export interface PolicyContext {
+  readonly at: IsoTimestamp;
+  readonly auditEventId: AuditEventId;
+}
+
+export interface CaptureRequest {
+  readonly id: ContributionId;
+  readonly cycleId: CycleId;
+  readonly memberId: MemberId;
+  readonly capturedAt: IsoTimestamp;
+  readonly mediaKind: MediaKind;
+  readonly durationSeconds: number;
+  readonly vignetteTreatment: VignetteTreatment;
+  readonly localUri: string | null;
+}
+
+export interface ValidateCaptureInput {
+  readonly request: CaptureRequest;
+  readonly group: Group;
+  readonly cycle: Cycle;
+  readonly existingContributions: readonly Contribution[];
+  readonly context: PolicyContext;
+}
+
+export interface ContributionBudget {
+  readonly usedCount: number;
+  readonly usedDurationSeconds: number;
+  readonly remainingCount: number;
+  readonly remainingDurationSeconds: number;
+}
+
+export type PolicyRejectionCode =
+  | "not-a-group-member"
+  | "cycle-mismatch"
+  | "cycle-not-collecting"
+  | "duplicate-contribution"
+  | "unsupported-media-kind"
+  | "unsupported-vignette-treatment"
+  | "photo-duration-must-be-three-seconds"
+  | "video-duration-out-of-range"
+  | "contribution-count-limit"
+  | "duration-budget-limit"
+  | "processing-state-invalid"
+  | "processing-attempt-invalid"
+  | "not-failed"
+  | "retry-limit-reached"
+  | "not-a-contributor"
+  | "cycle-reveal-closed"
+  | "already-deleted"
+  | "not-deletable-state"
+  | "invalid-week-key"
+  | "delete-limit-reached";
+
+export interface PolicyAccepted<T> {
+  readonly accepted: true;
+  readonly value: T;
+  readonly auditEvent: AuditEvent;
+  readonly idempotent: boolean;
+}
+
+export interface PolicyRejected {
+  readonly accepted: false;
+  readonly code: PolicyRejectionCode;
+  readonly reason: string;
+  readonly auditEvent: AuditEvent;
+}
+
+export type PolicyOutcome<T> = PolicyAccepted<T> | PolicyRejected;
+
+export interface ContributionTransitionInput {
+  readonly contribution: Contribution;
+  readonly context: PolicyContext;
+}
+
+export interface DeletionRecord {
+  readonly contributionId: ContributionId;
+  readonly memberId: MemberId;
+  readonly cycleId: CycleId;
+  /** A normalized simulated-week key supplied by the clock/time adapter. */
+  readonly weekKey: string;
+}
+
+export interface DeleteContributionInput {
+  readonly contribution: Contribution;
+  readonly group: Group;
+  readonly cycle: Cycle;
+  readonly actorMemberId: MemberId;
+  readonly weekKey: string;
+  readonly priorDeletions: readonly DeletionRecord[];
+  readonly context: PolicyContext;
+}
+
+export interface DeletedContribution {
+  readonly contribution: Contribution;
+  readonly deletion: DeletionRecord;
+}
+
+/** Rehydrate delete allowance state from the persisted local audit trail. */
+export function deletionRecordsFromAuditEvents(
+  events: readonly AuditEvent[],
+): readonly DeletionRecord[] {
+  return events.flatMap((event) => {
+    if (event.type !== "policy.contribution.deleted") {
+      return [];
+    }
+
+    const { contributionId, cycleId, memberId, weekKey } = event.metadata;
+    if (
+      typeof contributionId !== "string" ||
+      typeof cycleId !== "string" ||
+      typeof memberId !== "string" ||
+      typeof weekKey !== "string"
+    ) {
+      return [];
+    }
+
+    return [{ contributionId, cycleId, memberId, weekKey }];
+  });
+}
+
+/**
+ * Calculate the active per-member budget for a cycle. Deleted contributions do
+ * not consume either allowance, which is the quota-restoration rule for the
+ * one permitted delete.
+ */
+export function getContributionBudget(
+  contributions: readonly Contribution[],
+  memberId: MemberId,
+  cycleId: CycleId,
+): ContributionBudget {
+  const activeContributions = contributions.filter(
+    (contribution) =>
+      contribution.memberId === memberId &&
+      contribution.cycleId === cycleId &&
+      contribution.state !== "deleted",
+  );
+  const usedDurationSeconds = activeContributions.reduce(
+    (total, contribution) =>
+      Number.isFinite(contribution.durationSeconds)
+        ? total + contribution.durationSeconds
+        : total,
+    0,
+  );
+
+  return {
+    remainingCount: Math.max(
+      0,
+      MAX_CONTRIBUTIONS_PER_MEMBER - activeContributions.length,
+    ),
+    remainingDurationSeconds: Math.max(
+      0,
+      MAX_TOTAL_DURATION_SECONDS - usedDurationSeconds,
+    ),
+    usedCount: activeContributions.length,
+    usedDurationSeconds,
+  };
+}
+
+/**
+ * Validate and materialize a newly accepted capture without touching device
+ * APIs or persistence. The returned contribution is still `captured`; later
+ * lifecycle commands move it through processing and locking.
+ */
+export function validateCapture({
+  request,
+  group,
+  cycle,
+  existingContributions,
+  context,
+}: ValidateCaptureInput): PolicyOutcome<Contribution> {
+  if (!group.memberIds.includes(request.memberId)) {
+    return reject(
+      context,
+      request.id,
+      "not-a-group-member",
+      "Only a member of this local group can contribute.",
+    );
+  }
+
+  if (request.cycleId !== cycle.id || cycle.groupId !== group.id) {
+    return reject(
+      context,
+      request.id,
+      "cycle-mismatch",
+      "This contribution does not belong to the current group cycle.",
+    );
+  }
+
+  if (cycle.status !== "collecting") {
+    return reject(
+      context,
+      request.id,
+      "cycle-not-collecting",
+      "This cycle is not accepting new contributions.",
+    );
+  }
+
+  if (!isMediaKind(request.mediaKind)) {
+    return reject(
+      context,
+      request.id,
+      "unsupported-media-kind",
+      "Choose a photo or a short video.",
+    );
+  }
+
+  if (!isVignetteTreatment(request.vignetteTreatment)) {
+    return reject(
+      context,
+      request.id,
+      "unsupported-vignette-treatment",
+      "Choose one of the available original vignette treatments.",
+    );
+  }
+
+  if (
+    request.mediaKind === "photo" &&
+    request.durationSeconds !== PHOTO_DURATION_SECONDS
+  ) {
+    return reject(
+      context,
+      request.id,
+      "photo-duration-must-be-three-seconds",
+      "A photo uses a fixed three-second display duration.",
+    );
+  }
+
+  if (
+    request.mediaKind === "video" &&
+    (!Number.isFinite(request.durationSeconds) ||
+      request.durationSeconds < MIN_VIDEO_DURATION_SECONDS ||
+      request.durationSeconds > MAX_VIDEO_DURATION_SECONDS)
+  ) {
+    return reject(
+      context,
+      request.id,
+      "video-duration-out-of-range",
+      "Video duration must be between one and 15 seconds.",
+    );
+  }
+
+  if (existingContributions.some(({ id }) => id === request.id)) {
+    return reject(
+      context,
+      request.id,
+      "duplicate-contribution",
+      "This contribution has already been recorded.",
+    );
+  }
+
+  const budget = getContributionBudget(
+    existingContributions,
+    request.memberId,
+    request.cycleId,
+  );
+
+  if (budget.remainingCount === 0) {
+    return reject(
+      context,
+      request.id,
+      "contribution-count-limit",
+      "You have used all five contribution slots for this cycle.",
+    );
+  }
+
+  if (
+    budget.usedDurationSeconds + request.durationSeconds >
+    MAX_TOTAL_DURATION_SECONDS
+  ) {
+    return reject(
+      context,
+      request.id,
+      "duration-budget-limit",
+      "That contribution would exceed the 30-second cycle allowance.",
+    );
+  }
+
+  return accept(
+    context,
+    request.id,
+    {
+      ...request,
+      deletedAt: null,
+      processingAttempt: 0,
+      state: "captured",
+    },
+    "capture.accepted",
+  );
+}
+
+/** Start the first local processing attempt for a captured contribution. */
+export function startProcessing({
+  contribution,
+  context,
+}: ContributionTransitionInput): PolicyOutcome<Contribution> {
+  if (contribution.state === "processing") {
+    return accept(
+      context,
+      contribution.id,
+      contribution,
+      "processing.started",
+      true,
+    );
+  }
+
+  if (contribution.state !== "captured") {
+    return reject(
+      context,
+      contribution.id,
+      "processing-state-invalid",
+      "This contribution is not ready to start processing.",
+    );
+  }
+
+  if (contribution.processingAttempt !== 0) {
+    return reject(
+      context,
+      contribution.id,
+      "processing-attempt-invalid",
+      "This contribution already has a processing attempt.",
+    );
+  }
+
+  return accept(
+    context,
+    contribution.id,
+    { ...contribution, processingAttempt: 1, state: "processing" },
+    "processing.started",
+  );
+}
+
+/** Lock a successfully processed contribution; repeated completion is a no-op. */
+export function completeProcessing({
+  contribution,
+  context,
+}: ContributionTransitionInput): PolicyOutcome<Contribution> {
+  if (
+    contribution.state === "locked" ||
+    contribution.state === "revealed" ||
+    contribution.state === "archived"
+  ) {
+    return accept(
+      context,
+      contribution.id,
+      contribution,
+      "processing.completed",
+      true,
+    );
+  }
+
+  if (contribution.state !== "processing") {
+    return reject(
+      context,
+      contribution.id,
+      "processing-state-invalid",
+      "This contribution is not being processed.",
+    );
+  }
+
+  if (!isValidProcessingAttempt(contribution.processingAttempt)) {
+    return reject(
+      context,
+      contribution.id,
+      "processing-attempt-invalid",
+      "This contribution has an invalid processing attempt.",
+    );
+  }
+
+  return accept(
+    context,
+    contribution.id,
+    { ...contribution, state: "locked" },
+    "processing.completed",
+  );
+}
+
+/** Mark an active processing attempt as failed; repeating the failure is safe. */
+export function failProcessing({
+  contribution,
+  context,
+}: ContributionTransitionInput): PolicyOutcome<Contribution> {
+  if (contribution.state === "failed") {
+    return accept(
+      context,
+      contribution.id,
+      contribution,
+      "processing.failed",
+      true,
+    );
+  }
+
+  if (contribution.state !== "processing") {
+    return reject(
+      context,
+      contribution.id,
+      "processing-state-invalid",
+      "This contribution is not being processed.",
+    );
+  }
+
+  if (!isValidProcessingAttempt(contribution.processingAttempt)) {
+    return reject(
+      context,
+      contribution.id,
+      "processing-attempt-invalid",
+      "This contribution has an invalid processing attempt.",
+    );
+  }
+
+  return accept(
+    context,
+    contribution.id,
+    { ...contribution, state: "failed" },
+    "processing.failed",
+  );
+}
+
+/** Retry a failed contribution at most once in V1; duplicate retries are no-ops. */
+export function retryProcessing({
+  contribution,
+  context,
+}: ContributionTransitionInput): PolicyOutcome<Contribution> {
+  if (
+    contribution.state === "processing" ||
+    contribution.state === "locked" ||
+    contribution.state === "revealed" ||
+    contribution.state === "archived"
+  ) {
+    return accept(
+      context,
+      contribution.id,
+      contribution,
+      "processing.retried",
+      true,
+    );
+  }
+
+  if (contribution.state !== "failed") {
+    return reject(
+      context,
+      contribution.id,
+      "not-failed",
+      "Only a failed contribution can be retried.",
+    );
+  }
+
+  if (
+    !Number.isInteger(contribution.processingAttempt) ||
+    contribution.processingAttempt < 1
+  ) {
+    return reject(
+      context,
+      contribution.id,
+      "processing-attempt-invalid",
+      "This contribution has an invalid processing attempt.",
+    );
+  }
+
+  if (contribution.processingAttempt >= MAX_PROCESSING_ATTEMPTS) {
+    return reject(
+      context,
+      contribution.id,
+      "retry-limit-reached",
+      "This contribution has used its available retry.",
+    );
+  }
+
+  return accept(
+    context,
+    contribution.id,
+    {
+      ...contribution,
+      processingAttempt: contribution.processingAttempt + 1,
+      state: "processing",
+    },
+    "processing.retried",
+  );
+}
+
+/**
+ * Delete one pre-reveal contribution. The normalized week key is supplied by
+ * the injected clock/time adapter so this policy never guesses at timezone or
+ * DST semantics.
+ */
+export function deleteContribution({
+  contribution,
+  group,
+  cycle,
+  actorMemberId,
+  weekKey,
+  priorDeletions,
+  context,
+}: DeleteContributionInput): PolicyOutcome<DeletedContribution> {
+  if (!group.memberIds.includes(actorMemberId)) {
+    return reject(
+      context,
+      contribution.id,
+      "not-a-group-member",
+      "Only a member of this local group can delete a contribution.",
+    );
+  }
+
+  if (actorMemberId !== contribution.memberId) {
+    return reject(
+      context,
+      contribution.id,
+      "not-a-contributor",
+      "Only the contributor can delete this contribution.",
+    );
+  }
+
+  if (contribution.cycleId !== cycle.id || cycle.groupId !== group.id) {
+    return reject(
+      context,
+      contribution.id,
+      "cycle-mismatch",
+      "This contribution does not belong to the current group cycle.",
+    );
+  }
+
+  if (typeof weekKey !== "string" || weekKey.trim().length === 0) {
+    return reject(
+      context,
+      contribution.id,
+      "invalid-week-key",
+      "The simulated week is not available yet.",
+    );
+  }
+
+  if (contribution.state === "deleted") {
+    return reject(
+      context,
+      contribution.id,
+      "already-deleted",
+      "This contribution has already been deleted.",
+    );
+  }
+
+  if (contribution.state === "revealed" || contribution.state === "archived") {
+    return reject(
+      context,
+      contribution.id,
+      "cycle-reveal-closed",
+      "Revealed contributions can no longer be deleted.",
+    );
+  }
+
+  if (cycle.status === "premiere" || cycle.status === "archived") {
+    return reject(
+      context,
+      contribution.id,
+      "cycle-reveal-closed",
+      "This cycle has already been revealed.",
+    );
+  }
+
+  if (contribution.state === "recording") {
+    return reject(
+      context,
+      contribution.id,
+      "not-deletable-state",
+      "Finish or discard the active recording before deleting it.",
+    );
+  }
+
+  const deletionsThisWeek = priorDeletions.filter(
+    (deletion) =>
+      deletion.memberId === actorMemberId &&
+      deletion.cycleId === cycle.id &&
+      deletion.weekKey === weekKey,
+  ).length;
+
+  if (deletionsThisWeek >= MAX_DELETIONS_PER_WEEK) {
+    return reject(
+      context,
+      contribution.id,
+      "delete-limit-reached",
+      "Only one contribution can be deleted in the simulated week.",
+    );
+  }
+
+  const deletion: DeletionRecord = {
+    contributionId: contribution.id,
+    cycleId: cycle.id,
+    memberId: actorMemberId,
+    weekKey,
+  };
+
+  return accept(
+    context,
+    contribution.id,
+    {
+      contribution: {
+        ...contribution,
+        deletedAt: context.at,
+        state: "deleted",
+      },
+      deletion,
+    },
+    "contribution.deleted",
+    false,
+    {
+      contributionId: deletion.contributionId,
+      cycleId: deletion.cycleId,
+      memberId: deletion.memberId,
+      weekKey: deletion.weekKey,
+    },
+  );
+}
+
+/**
+ * Return only lock-safe pre-reveal summaries. No returned object contains a
+ * local URI, thumbnail URI, player source, or other media locator.
+ */
+export function listPreRevealContributionSummaries(
+  contributions: readonly Contribution[],
+): readonly SafeContributionSummary[] {
+  return contributions
+    .filter(
+      (contribution) =>
+        contribution.state !== "revealed" && contribution.state !== "archived",
+    )
+    .sort((left, right) =>
+      left.capturedAt === right.capturedAt
+        ? left.id.localeCompare(right.id)
+        : left.capturedAt.localeCompare(right.capturedAt),
+    )
+    .map(toSafeContributionSummary);
+}
+
+function isMediaKind(value: unknown): value is MediaKind {
+  return (
+    typeof value === "string" &&
+    (MEDIA_KINDS as readonly string[]).includes(value)
+  );
+}
+
+function isVignetteTreatment(value: unknown): value is VignetteTreatment {
+  return (
+    typeof value === "string" &&
+    (VIGNETTE_TREATMENTS as readonly string[]).includes(value)
+  );
+}
+
+function isValidProcessingAttempt(value: number): boolean {
+  return (
+    Number.isInteger(value) && value >= 1 && value <= MAX_PROCESSING_ATTEMPTS
+  );
+}
+
+function accept<T>(
+  context: PolicyContext,
+  subjectId: string,
+  value: T,
+  action: string,
+  idempotent = false,
+  metadata: Readonly<Record<string, string | number | boolean | null>> = {},
+): PolicyAccepted<T> {
+  return {
+    accepted: true,
+    auditEvent: makeAuditEvent(context, subjectId, action, {
+      idempotent,
+      ...metadata,
+    }),
+    idempotent,
+    value,
+  };
+}
+
+function reject(
+  context: PolicyContext,
+  subjectId: string,
+  code: PolicyRejectionCode,
+  reason: string,
+): PolicyRejected {
+  return {
+    accepted: false,
+    auditEvent: makeAuditEvent(context, subjectId, "rejected", {
+      code,
+      reason,
+    }),
+    code,
+    reason,
+  };
+}
+
+function makeAuditEvent(
+  context: PolicyContext,
+  subjectId: string,
+  action: string,
+  metadata: Readonly<Record<string, string | number | boolean | null>>,
+): AuditEvent {
+  return {
+    at: context.at,
+    id: context.auditEventId,
+    metadata: { action, ...metadata },
+    subjectId,
+    type: `policy.${action}`,
+  };
+}

--- a/packages/domain/src/policy/index.ts
+++ b/packages/domain/src/policy/index.ts
@@ -1,0 +1,1 @@
+export * from "./contribution-policy.ts";

--- a/packages/domain/tests/boundary.test.mjs
+++ b/packages/domain/tests/boundary.test.mjs
@@ -3,12 +3,8 @@ import { readdirSync, readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const sourceRoot = new URL("../src/", import.meta.url);
-const sourceFiles = readdirSync(sourceRoot).filter((file) =>
-  file.endsWith(".ts"),
-);
-const source = sourceFiles
-  .map((file) => readFileSync(new URL(file, sourceRoot), "utf8"))
-  .join("\n");
+const sourceFiles = collectTypeScriptFiles(sourceRoot);
+const source = sourceFiles.map((file) => readFileSync(file, "utf8")).join("\n");
 const imports = [...source.matchAll(/\b(?:from|import)\s*['"][^'"]+['"]/g)]
   .map(([statement]) => statement)
   .join("\n");
@@ -21,3 +17,17 @@ test("domain source stays independent of UI, persistence, and vendor modules", (
   );
   assert.doesNotMatch(source, /https?:\/\//i);
 });
+
+function collectTypeScriptFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryUrl = new URL(
+      `${entry.name}${entry.isDirectory() ? "/" : ""}`,
+      directory,
+    );
+    return entry.isDirectory()
+      ? collectTypeScriptFiles(entryUrl)
+      : entry.name.endsWith(".ts")
+        ? [entryUrl]
+        : [];
+  });
+}

--- a/packages/domain/tests/policy.test.mjs
+++ b/packages/domain/tests/policy.test.mjs
@@ -1,0 +1,430 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { seededCycle, seededGroup } from "../src/fixtures.ts";
+import {
+  MAX_CONTRIBUTIONS_PER_MEMBER,
+  MAX_PROCESSING_ATTEMPTS,
+  MAX_TOTAL_DURATION_SECONDS,
+  MAX_VIDEO_DURATION_SECONDS,
+  MIN_VIDEO_DURATION_SECONDS,
+  PHOTO_DURATION_SECONDS,
+  completeProcessing,
+  deleteContribution,
+  deletionRecordsFromAuditEvents,
+  failProcessing,
+  getContributionBudget,
+  listPreRevealContributionSummaries,
+  retryProcessing,
+  startProcessing,
+  validateCapture,
+} from "../src/index.ts";
+
+const NOW = "2026-08-30T10:00:00.000Z";
+
+const baseContext = (id) => ({
+  at: NOW,
+  auditEventId: id,
+});
+
+const baseRequest = (overrides = {}) => ({
+  id: "contribution-new",
+  cycleId: seededCycle.id,
+  memberId: "member-ava",
+  capturedAt: "2026-08-30T10:00:00.000Z",
+  mediaKind: "video",
+  durationSeconds: 5,
+  vignetteTreatment: "ccd",
+  localUri: "file:///synthetic/new.mov",
+  ...overrides,
+});
+
+const baseContribution = (overrides = {}) => ({
+  id: "contribution-policy",
+  cycleId: seededCycle.id,
+  memberId: "member-ava",
+  capturedAt: "2026-08-30T10:00:00.000Z",
+  mediaKind: "video",
+  durationSeconds: 5,
+  vignetteTreatment: "ccd",
+  localUri: "file:///synthetic/policy.mov",
+  state: "captured",
+  processingAttempt: 0,
+  deletedAt: null,
+  ...overrides,
+});
+
+function assertRejected(outcome, code) {
+  assert.equal(outcome.accepted, false);
+  assert.equal(outcome.code, code);
+  assert.equal(typeof outcome.reason, "string");
+  assert.ok(outcome.reason.length > 0);
+  assert.equal(outcome.auditEvent.type, "policy.rejected");
+  assert.equal(outcome.auditEvent.metadata.code, code);
+  assert.equal(outcome.auditEvent.metadata.reason, outcome.reason);
+}
+
+function validate(
+  request,
+  existingContributions = [],
+  contextId = "audit-capture",
+) {
+  return validateCapture({
+    context: baseContext(contextId),
+    cycle: seededCycle,
+    existingContributions,
+    group: seededGroup,
+    request,
+  });
+}
+
+test("capture policy enforces membership, media duration, five slots, and 30 seconds", () => {
+  const oneSecondVideo = validate(
+    baseRequest({ durationSeconds: MIN_VIDEO_DURATION_SECONDS }),
+    [],
+    "audit-video-min",
+  );
+  assert.equal(oneSecondVideo.accepted, true);
+
+  const fifteenSecondVideo = validate(
+    baseRequest({
+      durationSeconds: MAX_VIDEO_DURATION_SECONDS,
+      id: "contribution-video-max",
+    }),
+    [],
+    "audit-video-max",
+  );
+  assert.equal(fifteenSecondVideo.accepted, true);
+
+  assertRejected(
+    validate(
+      baseRequest({ durationSeconds: MIN_VIDEO_DURATION_SECONDS - 1 }),
+      [],
+      "audit-video-too-short",
+    ),
+    "video-duration-out-of-range",
+  );
+  assertRejected(
+    validate(
+      baseRequest({ durationSeconds: MAX_VIDEO_DURATION_SECONDS + 1 }),
+      [],
+      "audit-video-too-long",
+    ),
+    "video-duration-out-of-range",
+  );
+
+  const photo = validate(
+    baseRequest({
+      durationSeconds: PHOTO_DURATION_SECONDS,
+      id: "contribution-photo",
+      mediaKind: "photo",
+      localUri: "file:///synthetic/new.jpg",
+    }),
+    [],
+    "audit-photo",
+  );
+  assert.equal(photo.accepted, true);
+  assert.equal(photo.value.durationSeconds, PHOTO_DURATION_SECONDS);
+  assertRejected(
+    validate(
+      baseRequest({
+        durationSeconds: PHOTO_DURATION_SECONDS - 1,
+        id: "contribution-photo-invalid",
+        mediaKind: "photo",
+      }),
+      [],
+      "audit-photo-invalid",
+    ),
+    "photo-duration-must-be-three-seconds",
+  );
+
+  const fourContributions = Array.from(
+    { length: MAX_CONTRIBUTIONS_PER_MEMBER - 1 },
+    (_, index) =>
+      baseContribution({
+        id: `contribution-slot-${index}`,
+        durationSeconds: 3,
+        state: "locked",
+      }),
+  );
+  const fifth = validate(
+    baseRequest({ durationSeconds: 3, id: "contribution-slot-five" }),
+    fourContributions,
+    "audit-slot-five",
+  );
+  assert.equal(fifth.accepted, true);
+
+  const fiveContributions = [
+    ...fourContributions,
+    baseContribution({
+      id: "contribution-slot-five-existing",
+      durationSeconds: 3,
+    }),
+  ];
+  assertRejected(
+    validate(
+      baseRequest({ durationSeconds: 3, id: "contribution-slot-six" }),
+      fiveContributions,
+      "audit-slot-six",
+    ),
+    "contribution-count-limit",
+  );
+
+  const durationAtLimit = [
+    baseContribution({ id: "contribution-duration-15", durationSeconds: 15 }),
+    baseContribution({ id: "contribution-duration-12", durationSeconds: 12 }),
+  ];
+  const exactlyThirty = validate(
+    baseRequest({ durationSeconds: 3, id: "contribution-duration-30" }),
+    durationAtLimit,
+    "audit-duration-thirty",
+  );
+  assert.equal(exactlyThirty.accepted, true);
+  assertRejected(
+    validate(
+      baseRequest({ durationSeconds: 4, id: "contribution-duration-31" }),
+      durationAtLimit,
+      "audit-duration-thirty-one",
+    ),
+    "duration-budget-limit",
+  );
+
+  assertRejected(
+    validate(
+      baseRequest({ id: "contribution-audio", mediaKind: "audio" }),
+      [],
+      "audit-media-kind",
+    ),
+    "unsupported-media-kind",
+  );
+  assertRejected(
+    validate(
+      baseRequest({ id: "contribution-duplicate" }),
+      [baseContribution({ id: "contribution-duplicate" })],
+      "audit-duplicate",
+    ),
+    "duplicate-contribution",
+  );
+  assertRejected(
+    validate(
+      baseRequest({ id: "contribution-outsider", memberId: "member-outsider" }),
+      [],
+      "audit-outsider",
+    ),
+    "not-a-group-member",
+  );
+});
+
+test("delete policy restores quota once and rejects a second same-week delete without mutation", () => {
+  const contribution = baseContribution({
+    id: "contribution-delete-one",
+    durationSeconds: 10,
+  });
+  const first = deleteContribution({
+    actorMemberId: contribution.memberId,
+    context: baseContext("audit-delete-one"),
+    contribution,
+    cycle: seededCycle,
+    group: seededGroup,
+    priorDeletions: [],
+    weekKey: "2026-W35",
+  });
+
+  assert.equal(first.accepted, true);
+  assert.equal(first.value.contribution.state, "deleted");
+  assert.equal(first.value.contribution.deletedAt, NOW);
+  assert.deepEqual(first.value.deletion, {
+    contributionId: contribution.id,
+    cycleId: seededCycle.id,
+    memberId: contribution.memberId,
+    weekKey: "2026-W35",
+  });
+  assert.deepEqual(deletionRecordsFromAuditEvents([first.auditEvent]), [
+    first.value.deletion,
+  ]);
+  assert.deepEqual(
+    getContributionBudget(
+      [first.value.contribution],
+      contribution.memberId,
+      seededCycle.id,
+    ),
+    {
+      remainingCount: MAX_CONTRIBUTIONS_PER_MEMBER,
+      remainingDurationSeconds: MAX_TOTAL_DURATION_SECONDS,
+      usedCount: 0,
+      usedDurationSeconds: 0,
+    },
+  );
+  const retake = validate(
+    baseRequest({ durationSeconds: 15, id: "contribution-retake" }),
+    [first.value.contribution],
+    "audit-retake",
+  );
+  assert.equal(retake.accepted, true);
+
+  const secondContribution = baseContribution({
+    id: "contribution-delete-two",
+    durationSeconds: 4,
+  });
+  const second = deleteContribution({
+    actorMemberId: secondContribution.memberId,
+    context: baseContext("audit-delete-two"),
+    contribution: secondContribution,
+    cycle: seededCycle,
+    group: seededGroup,
+    priorDeletions: deletionRecordsFromAuditEvents([first.auditEvent]),
+    weekKey: "2026-W35",
+  });
+  assertRejected(second, "delete-limit-reached");
+  assert.equal(secondContribution.state, "captured");
+
+  const nextWeek = deleteContribution({
+    actorMemberId: secondContribution.memberId,
+    context: baseContext("audit-delete-next-week"),
+    contribution: secondContribution,
+    cycle: seededCycle,
+    group: seededGroup,
+    priorDeletions: [first.value.deletion],
+    weekKey: "2026-W36",
+  });
+  assert.equal(nextWeek.accepted, true);
+
+  assertRejected(
+    deleteContribution({
+      actorMemberId: contribution.memberId,
+      context: baseContext("audit-delete-again"),
+      contribution: first.value.contribution,
+      cycle: seededCycle,
+      group: seededGroup,
+      priorDeletions: [first.value.deletion],
+      weekKey: "2026-W35",
+    }),
+    "already-deleted",
+  );
+  assertRejected(
+    deleteContribution({
+      actorMemberId: "member-ben",
+      context: baseContext("audit-delete-owner"),
+      contribution,
+      cycle: seededCycle,
+      group: seededGroup,
+      priorDeletions: [],
+      weekKey: "2026-W37",
+    }),
+    "not-a-contributor",
+  );
+});
+
+test("processing transitions are bounded, auditable, and idempotent", () => {
+  const captured = baseContribution();
+  const processing = startProcessing({
+    context: baseContext("audit-processing-start"),
+    contribution: captured,
+  });
+  assert.equal(processing.accepted, true);
+  assert.equal(processing.value.state, "processing");
+  assert.equal(processing.value.processingAttempt, 1);
+
+  const duplicateStart = startProcessing({
+    context: baseContext("audit-processing-start-duplicate"),
+    contribution: processing.value,
+  });
+  assert.equal(duplicateStart.accepted, true);
+  assert.equal(duplicateStart.idempotent, true);
+  assert.deepEqual(duplicateStart.value, processing.value);
+
+  const failed = failProcessing({
+    context: baseContext("audit-processing-failed"),
+    contribution: processing.value,
+  });
+  assert.equal(failed.accepted, true);
+  assert.equal(failed.value.state, "failed");
+  assert.equal(failed.value.processingAttempt, 1);
+
+  const retried = retryProcessing({
+    context: baseContext("audit-processing-retry"),
+    contribution: failed.value,
+  });
+  assert.equal(retried.accepted, true);
+  assert.equal(retried.value.state, "processing");
+  assert.equal(retried.value.processingAttempt, MAX_PROCESSING_ATTEMPTS);
+
+  const duplicateRetry = retryProcessing({
+    context: baseContext("audit-processing-retry-duplicate"),
+    contribution: retried.value,
+  });
+  assert.equal(duplicateRetry.accepted, true);
+  assert.equal(duplicateRetry.idempotent, true);
+  assert.deepEqual(duplicateRetry.value, retried.value);
+
+  const locked = completeProcessing({
+    context: baseContext("audit-processing-complete"),
+    contribution: retried.value,
+  });
+  assert.equal(locked.accepted, true);
+  assert.equal(locked.value.state, "locked");
+
+  const duplicateCompletion = completeProcessing({
+    context: baseContext("audit-processing-complete-duplicate"),
+    contribution: locked.value,
+  });
+  assert.equal(duplicateCompletion.accepted, true);
+  assert.equal(duplicateCompletion.idempotent, true);
+  assert.deepEqual(duplicateCompletion.value, locked.value);
+
+  const failedSecondAttempt = failProcessing({
+    context: baseContext("audit-processing-failed-second"),
+    contribution: retried.value,
+  });
+  const exhaustedRetry = retryProcessing({
+    context: baseContext("audit-processing-retry-exhausted"),
+    contribution: failedSecondAttempt.value,
+  });
+  assertRejected(exhaustedRetry, "retry-limit-reached");
+  assert.equal(
+    failedSecondAttempt.value.processingAttempt,
+    MAX_PROCESSING_ATTEMPTS,
+  );
+  assert.equal(failedSecondAttempt.value.state, "failed");
+
+  assertRejected(
+    completeProcessing({
+      context: baseContext("audit-processing-invalid"),
+      contribution: captured,
+    }),
+    "processing-state-invalid",
+  );
+  assertRejected(
+    retryProcessing({
+      context: baseContext("audit-processing-not-failed"),
+      contribution: captured,
+    }),
+    "not-failed",
+  );
+});
+
+test("pre-reveal summaries never expose media locators", () => {
+  const summaries = listPreRevealContributionSummaries([
+    baseContribution({
+      id: "locked-later",
+      capturedAt: "2026-08-30T11:00:00.000Z",
+      state: "locked",
+    }),
+    baseContribution({ id: "revealed", state: "revealed" }),
+    baseContribution({
+      id: "locked-earlier",
+      capturedAt: "2026-08-30T09:00:00.000Z",
+      state: "locked",
+    }),
+  ]);
+
+  assert.deepEqual(
+    summaries.map(({ id }) => id),
+    ["locked-earlier", "locked-later"],
+  );
+  for (const summary of summaries) {
+    assert.equal("localUri" in summary, false);
+    assert.equal("thumbnailUri" in summary, false);
+    assert.equal("playerSource" in summary, false);
+  }
+});


### PR DESCRIPTION
## Summary

- enforce membership, media duration, five-slot, and 30-second contribution rules
- model bounded processing, failure, retry, lock, and one-delete transitions
- return user-safe rejection reasons with audit events
- keep pre-reveal summaries free of media locators and rehydrate delete audits

## Verification

- `npm --prefix packages/domain test`
- `npm --prefix packages/domain run typecheck`
- `make check`
- `npm --prefix apps/mobile run build:web`

All pass with synthetic fixtures. See [issue 16 evidence](https://github.com/Collaboration95/rewind-v1/blob/main/evidence/issues/16/completion.md).

Closes #16