### PR TITLE
feat(domain): add simulation clock and local playlist

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -53,7 +53,7 @@
     "test": "node scripts/test.cjs && jest --runInBand",
     "test:contracts": "node scripts/test.cjs",
     "test:database": "node --experimental-strip-types --test tests/local-database.test.mjs",
-    "test:domain": "node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs ../../packages/domain/tests/policy.test.mjs",
+    "test:domain": "node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs ../../packages/domain/tests/policy.test.mjs ../../packages/domain/tests/simulation.test.mjs",
     "test:unit": "jest --runInBand",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm run test"
   }

--- a/apps/mobile/scripts/test.cjs
+++ b/apps/mobile/scripts/test.cjs
@@ -16,6 +16,7 @@ const result = spawnSync(
     '../../packages/domain/tests/domain.test.mjs',
     '../../packages/domain/tests/boundary.test.mjs',
     '../../packages/domain/tests/policy.test.mjs',
+    '../../packages/domain/tests/simulation.test.mjs',
   ],
   { stdio: 'inherit' },
 );

--- a/apps/mobile/tests/tooling.test.mjs
+++ b/apps/mobile/tests/tooling.test.mjs
@@ -36,7 +36,7 @@ test('mobile quality scripts are deterministic and non-watch', () => {
   );
   assert.equal(
     scripts['test:domain'],
-    'node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs ../../packages/domain/tests/policy.test.mjs',
+    'node --experimental-strip-types --test ../../packages/domain/tests/domain.test.mjs ../../packages/domain/tests/boundary.test.mjs ../../packages/domain/tests/policy.test.mjs ../../packages/domain/tests/simulation.test.mjs',
   );
   assert.equal(scripts['test:unit'], 'jest --runInBand');
 
@@ -46,7 +46,7 @@ test('mobile quality scripts are deterministic and non-watch', () => {
   );
   assert.equal(
     domainManifest.scripts.test,
-    'node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs tests/policy.test.mjs',
+    'node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs tests/policy.test.mjs tests/simulation.test.mjs',
   );
 
   assert.match(jestConfig, /preset: 'jest-expo'/);

--- a/evidence/issues/17/completion.md
+++ b/evidence/issues/17/completion.md
@@ -1,0 +1,58 @@
+# Issue 17 completion evidence
+
+- Issue: [#17 — Add deterministic simulation clock and local capsule assembler](https://github.com/Collaboration95/rewind-v1/issues/17)
+- Branch: `codex/17-simulation-clock-playlist`
+- Implementation commit: [e885f04](https://github.com/Collaboration95/rewind-v1/commit/e885f04ecf1992abda4aa4e0ee7e157709efcf5e)
+
+## Scope delivered
+
+Added a framework-free simulation clock with deterministic minute, day, and
+four-week-equivalent steps. It advances an injected ISO instant without
+sleeping or reading wall time; `real` mode remains unchanged for the simulation
+command because a device clock adapter owns that behavior.
+
+Added explicit cycle transitions:
+
+```text
+collecting → reveal_pending → premiere → archived
+                    │
+                    └──────→ delayed → premiere
+```
+
+Collection cannot close before its end instant. Premiere requires all active
+contributions to be locked, revealed, or already archived; failed processing
+must take the delayed path and recover before premiere. Repeated transitions
+are idempotent and transition failures carry safe reasons plus audit events.
+
+The capsule assembler is reveal-gated and returns a value explicitly marked
+`local-playlist` containing only deterministically capture-time-ordered
+contribution IDs. It does not expose media URIs, generate a combined media
+file, or choose an unresolved low-contribution filler policy.
+
+## Verification
+
+- `npm --prefix packages/domain test` — PASS (11 direct domain tests).
+- `npm --prefix packages/domain run typecheck` — PASS.
+- `make check` — PASS (workflow validation, formatting, lint, app/domain typechecks, 20 Node contract tests, and one Jest/RNTL smoke test).
+- `npm --prefix apps/mobile run build:web` — PASS (Expo web export).
+- `git diff --check` — PASS.
+
+Relevant output:
+
+```text
+ℹ tests 11
+ℹ pass 11
+```
+
+The deterministic test suite covers minute/day/four-week advancement, repeated
+steps, invalid negative steps, collection-end gating, all cycle statuses,
+delayed processing failure and recovery, deterministic tie ordering, filtering
+of ineligible/unrelated contributions, and pre-reveal gating.
+
+## Device and product-decision limitations
+
+This ticket is pure domain logic and intentionally adds no simulation route or
+device operation, so no simulator screenshot or native-clock claim is made.
+The real-mode clock behavior and timezone/DST week-key normalization remain
+owned by future adapters; no wall-clock sleeps, network service, cloud media, or
+personal data were used.

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -34,3 +34,14 @@ audits carry the normalized week key and can be rehydrated after relaunch. V1
 allows five contributions and 30 total seconds per member/cycle, fixed
 three-second photos, 1–15 second videos, one retry, and one delete per
 simulated week.
+
+## Simulation and capsule assembly
+
+`src/time/` advances an injected instant by deterministic minute, day, or
+four-week-equivalent steps without sleeping. `real` mode is intentionally a
+no-op for the simulation command because a device clock adapter supplies that
+instant. `src/capsule/` and `src/cycle/` document the collecting →
+reveal-pending → premiere → archived path and the delayed processing-failure
+path. The assembler returns a `local-playlist` containing chronologically
+ordered eligible contribution IDs; it never creates a combined media file or
+chooses a low-contribution filler policy.

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -8,6 +8,6 @@
   },
   "scripts": {
     "typecheck": "../../apps/mobile/node_modules/.bin/tsc --noEmit -p tsconfig.json",
-    "test": "node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs tests/policy.test.mjs"
+    "test": "node --experimental-strip-types --test tests/domain.test.mjs tests/boundary.test.mjs tests/policy.test.mjs tests/simulation.test.mjs"
   }
 }

--- a/packages/domain/src/capsule/index.ts
+++ b/packages/domain/src/capsule/index.ts
@@ -1,0 +1,1 @@
+export * from "./local-playlist.ts";

--- a/packages/domain/src/capsule/local-playlist.ts
+++ b/packages/domain/src/capsule/local-playlist.ts
@@ -1,0 +1,45 @@
+import type {
+  Contribution,
+  ContributionId,
+  Cycle,
+  CycleId,
+} from "../models.ts";
+import { isRevealEligibleContribution } from "../cycle/cycle-policy.ts";
+
+export interface LocalPlaylist {
+  /** Deliberately distinguishes an ordered list from a rendered media file. */
+  readonly kind: "local-playlist";
+  readonly cycleId: CycleId;
+  readonly contributionIds: readonly ContributionId[];
+}
+
+/**
+ * Assemble an ordered list of local contribution IDs after reveal. No media
+ * file is generated and no URI is returned by this domain function.
+ */
+export function assembleLocalPlaylist(
+  cycle: Cycle,
+  contributions: readonly Contribution[],
+): LocalPlaylist {
+  const contributionIds =
+    cycle.status === "premiere" || cycle.status === "archived"
+      ? contributions
+          .filter(
+            (contribution) =>
+              contribution.cycleId === cycle.id &&
+              isRevealEligibleContribution(contribution),
+          )
+          .sort((left, right) =>
+            left.capturedAt === right.capturedAt
+              ? left.id.localeCompare(right.id)
+              : left.capturedAt.localeCompare(right.capturedAt),
+          )
+          .map(({ id }) => id)
+      : [];
+
+  return {
+    contributionIds,
+    cycleId: cycle.id,
+    kind: "local-playlist",
+  };
+}

--- a/packages/domain/src/cycle/cycle-policy.ts
+++ b/packages/domain/src/cycle/cycle-policy.ts
@@ -1,0 +1,236 @@
+import type {
+  AuditEvent,
+  AuditEventId,
+  Contribution,
+  Cycle,
+  CycleStatus,
+  IsoTimestamp,
+} from "../models.ts";
+import { addIsoSeconds } from "../time/simulation-clock.ts";
+
+export interface CyclePolicyContext {
+  readonly at: IsoTimestamp;
+  readonly auditEventId: AuditEventId;
+}
+
+export interface CycleTransitionInput {
+  readonly cycle: Cycle;
+  readonly targetStatus: CycleStatus;
+  readonly contributions: readonly Contribution[];
+  readonly context: CyclePolicyContext;
+}
+
+export type CycleRejectionCode =
+  | "cycle-not-ready"
+  | "invalid-transition"
+  | "contributions-not-locked"
+  | "failed-contributions-require-delay"
+  | "delay-requires-processing-failure"
+  | "processing-failure-remains";
+
+export interface CycleTransitionAccepted {
+  readonly accepted: true;
+  readonly cycle: Cycle;
+  readonly auditEvent: AuditEvent;
+  readonly idempotent: boolean;
+}
+
+export interface CycleTransitionRejected {
+  readonly accepted: false;
+  readonly code: CycleRejectionCode;
+  readonly reason: string;
+  readonly auditEvent: AuditEvent;
+}
+
+export type CycleTransitionOutcome =
+  CycleTransitionAccepted | CycleTransitionRejected;
+
+export const REVEAL_ELIGIBLE_CONTRIBUTION_STATES = [
+  "locked",
+  "revealed",
+  "archived",
+] as const;
+
+/** Return the instant at which a collecting cycle ends. */
+export function cycleEndAt(cycle: Cycle): IsoTimestamp {
+  return addIsoSeconds(cycle.startAt, cycle.durationSeconds);
+}
+
+/**
+ * Move a cycle through the explicit local reveal state machine. The caller
+ * supplies the current instant and contributions; this function performs no
+ * persistence or wall-clock scheduling.
+ */
+export function transitionCycle({
+  cycle,
+  targetStatus,
+  contributions,
+  context,
+}: CycleTransitionInput): CycleTransitionOutcome {
+  if (cycle.status === targetStatus) {
+    return accept(context, cycle, true);
+  }
+
+  if (cycle.status === "collecting" && targetStatus === "reveal_pending") {
+    if (Date.parse(context.at) < Date.parse(cycleEndAt(cycle))) {
+      return reject(
+        context,
+        cycle.id,
+        "cycle-not-ready",
+        "The cycle is still collecting contributions.",
+      );
+    }
+    return accept(
+      context,
+      { ...cycle, status: "reveal_pending" },
+      false,
+      cycle.status,
+    );
+  }
+
+  if (cycle.status === "reveal_pending" && targetStatus === "delayed") {
+    if (!hasFailedContribution(cycle, contributions)) {
+      return reject(
+        context,
+        cycle.id,
+        "delay-requires-processing-failure",
+        "The cycle can be delayed only when processing has failed.",
+      );
+    }
+    return accept(
+      context,
+      { ...cycle, status: "delayed" },
+      false,
+      cycle.status,
+    );
+  }
+
+  if (
+    (cycle.status === "reveal_pending" || cycle.status === "delayed") &&
+    targetStatus === "premiere"
+  ) {
+    if (hasFailedContribution(cycle, contributions)) {
+      return reject(
+        context,
+        cycle.id,
+        cycle.status === "delayed"
+          ? "processing-failure-remains"
+          : "failed-contributions-require-delay",
+        cycle.status === "delayed"
+          ? "Retry the failed contributions before starting the premiere."
+          : "Move the cycle to delayed while a contribution has failed.",
+      );
+    }
+
+    if (!allContributionsReady(cycle, contributions)) {
+      return reject(
+        context,
+        cycle.id,
+        "contributions-not-locked",
+        "All contributions must finish processing before the premiere.",
+      );
+    }
+    return accept(
+      context,
+      { ...cycle, status: "premiere" },
+      false,
+      cycle.status,
+    );
+  }
+
+  if (cycle.status === "premiere" && targetStatus === "archived") {
+    return accept(
+      context,
+      { ...cycle, status: "archived" },
+      false,
+      cycle.status,
+    );
+  }
+
+  return reject(
+    context,
+    cycle.id,
+    "invalid-transition",
+    `The cycle cannot move from ${cycle.status} to ${targetStatus}.`,
+  );
+}
+
+export function isRevealEligibleContribution(
+  contribution: Contribution,
+): boolean {
+  return (REVEAL_ELIGIBLE_CONTRIBUTION_STATES as readonly string[]).includes(
+    contribution.state,
+  );
+}
+
+function hasFailedContribution(
+  cycle: Cycle,
+  contributions: readonly Contribution[],
+): boolean {
+  return contributions.some(
+    (contribution) =>
+      contribution.cycleId === cycle.id && contribution.state === "failed",
+  );
+}
+
+function allContributionsReady(
+  cycle: Cycle,
+  contributions: readonly Contribution[],
+): boolean {
+  return contributions
+    .filter(
+      (contribution) =>
+        contribution.cycleId === cycle.id && contribution.state !== "deleted",
+    )
+    .every(isRevealEligibleContribution);
+}
+
+function accept(
+  context: CyclePolicyContext,
+  cycle: Cycle,
+  idempotent: boolean,
+  previousStatus = cycle.status,
+): CycleTransitionAccepted {
+  return {
+    accepted: true,
+    auditEvent: makeAuditEvent(context, cycle.id, "transitioned", {
+      from: previousStatus,
+      idempotent,
+      to: cycle.status,
+    }),
+    cycle,
+    idempotent,
+  };
+}
+
+function reject(
+  context: CyclePolicyContext,
+  subjectId: string,
+  code: CycleRejectionCode,
+  reason: string,
+): CycleTransitionRejected {
+  return {
+    accepted: false,
+    auditEvent: makeAuditEvent(context, subjectId, "rejected", {
+      code,
+      reason,
+    }),
+    code,
+    reason,
+  };
+}
+
+function makeAuditEvent(
+  context: CyclePolicyContext,
+  subjectId: string,
+  action: string,
+  metadata: Readonly<Record<string, string | number | boolean | null>>,
+): AuditEvent {
+  return {
+    at: context.at,
+    id: context.auditEventId,
+    metadata: { action, ...metadata },
+    subjectId,
+    type: `cycle.${action}`,
+  };
+}

--- a/packages/domain/src/cycle/index.ts
+++ b/packages/domain/src/cycle/index.ts
@@ -1,0 +1,1 @@
+export * from "./cycle-policy.ts";

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,4 +1,7 @@
 export * from "./fixtures.ts";
 export * from "./models.ts";
+export * from "./capsule/index.ts";
+export * from "./cycle/index.ts";
 export * from "./policy/index.ts";
 export * from "./ports.ts";
+export * from "./time/index.ts";

--- a/packages/domain/src/time/index.ts
+++ b/packages/domain/src/time/index.ts
@@ -1,0 +1,1 @@
+export * from "./simulation-clock.ts";

--- a/packages/domain/src/time/simulation-clock.ts
+++ b/packages/domain/src/time/simulation-clock.ts
@@ -1,0 +1,62 @@
+import type {
+  IsoTimestamp,
+  SimulationClock,
+  SimulationMode,
+} from "../models.ts";
+
+export const FOUR_WEEK_SECONDS = 4 * 7 * 24 * 60 * 60;
+export const SIMULATION_MODE_STEP_SECONDS: Readonly<
+  Record<SimulationMode, number>
+> = {
+  real: 0,
+  "demo-minute": 60,
+  "demo-day": 24 * 60 * 60,
+  "demo-cycle": FOUR_WEEK_SECONDS,
+};
+
+/** The deterministic amount advanced by one console step for a mode. */
+export function simulationStepSeconds(mode: SimulationMode): number {
+  return SIMULATION_MODE_STEP_SECONDS[mode];
+}
+
+/**
+ * Advance a local simulation clock without sleeping or reading wall time. The
+ * `real` mode intentionally remains unchanged; a production-style adapter
+ * supplies its current instant through the ClockPort instead.
+ */
+export function advanceSimulationClock(
+  clock: SimulationClock,
+  steps = 1,
+): SimulationClock {
+  if (!Number.isInteger(steps) || steps < 0) {
+    throw new RangeError(
+      "Simulation clock steps must be a non-negative integer",
+    );
+  }
+
+  const seconds = simulationStepSeconds(clock.mode) * steps;
+  return seconds === 0
+    ? clock
+    : { ...clock, now: addIsoSeconds(clock.now, seconds) };
+}
+
+/** Switch a local clock mode while preserving its deterministic instant. */
+export function setSimulationMode(
+  clock: SimulationClock,
+  mode: SimulationMode,
+): SimulationClock {
+  return clock.mode === mode ? clock : { ...clock, mode };
+}
+
+/** Add whole seconds to an ISO timestamp in UTC. */
+export function addIsoSeconds(
+  timestamp: IsoTimestamp,
+  seconds: number,
+): IsoTimestamp {
+  const milliseconds = Date.parse(timestamp);
+  if (!Number.isFinite(milliseconds)) {
+    throw new RangeError(`Invalid ISO timestamp: ${timestamp}`);
+  }
+
+  return new Date(milliseconds + seconds * 1000).toISOString();
+}

--- a/packages/domain/tests/simulation.test.mjs
+++ b/packages/domain/tests/simulation.test.mjs
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  FOUR_WEEK_SECONDS,
+  SIMULATION_MODE_STEP_SECONDS,
+  advanceSimulationClock,
+  assembleLocalPlaylist,
+  cycleEndAt,
+  seededContributions,
+  seededCycle,
+  seededDomainFixture,
+  seededGroup,
+  setSimulationMode,
+  transitionCycle,
+} from "../src/index.ts";
+
+const context = (id, at = "2026-08-30T10:00:00.000Z") => ({
+  at,
+  auditEventId: id,
+});
+
+function assertRejected(outcome, code) {
+  assert.equal(outcome.accepted, false);
+  assert.equal(outcome.code, code);
+  assert.equal(typeof outcome.reason, "string");
+  assert.ok(outcome.reason.length > 0);
+  assert.equal(outcome.auditEvent.type, "cycle.rejected");
+  assert.equal(outcome.auditEvent.metadata.code, code);
+}
+
+test("simulation clock advances minute, day, and four-week modes without sleeping", () => {
+  const initial = { now: "2026-08-30T10:00:00.000Z", mode: "demo-minute" };
+  assert.equal(SIMULATION_MODE_STEP_SECONDS["demo-minute"], 60);
+  assert.equal(advanceSimulationClock(initial).now, "2026-08-30T10:01:00.000Z");
+  assert.equal(
+    advanceSimulationClock(initial, 3).now,
+    "2026-08-30T10:03:00.000Z",
+  );
+
+  const dayClock = setSimulationMode(initial, "demo-day");
+  assert.equal(
+    advanceSimulationClock(dayClock).now,
+    "2026-08-31T10:00:00.000Z",
+  );
+
+  const cycleClock = setSimulationMode(initial, "demo-cycle");
+  assert.equal(SIMULATION_MODE_STEP_SECONDS["demo-cycle"], FOUR_WEEK_SECONDS);
+  assert.equal(
+    advanceSimulationClock(cycleClock).now,
+    "2026-09-27T10:00:00.000Z",
+  );
+
+  const realClock = setSimulationMode(initial, "real");
+  assert.deepEqual(advanceSimulationClock(realClock), realClock);
+  assert.throws(
+    () => advanceSimulationClock(initial, -1),
+    /non-negative integer/,
+  );
+});
+
+test("cycle transitions enforce collection end and document the happy path", () => {
+  const fourWeekCycle = {
+    ...seededCycle,
+    durationSeconds: FOUR_WEEK_SECONDS,
+  };
+  const early = transitionCycle({
+    context: context("audit-cycle-early", "2026-08-30T10:00:00.000Z"),
+    contributions: seededContributions,
+    cycle: fourWeekCycle,
+    targetStatus: "reveal_pending",
+  });
+  assertRejected(early, "cycle-not-ready");
+
+  const pending = transitionCycle({
+    context: context("audit-cycle-pending", cycleEndAt(fourWeekCycle)),
+    contributions: seededContributions,
+    cycle: fourWeekCycle,
+    targetStatus: "reveal_pending",
+  });
+  assert.equal(pending.accepted, true);
+  assert.equal(pending.cycle.status, "reveal_pending");
+  assert.equal(pending.auditEvent.metadata.from, "collecting");
+  assert.equal(pending.auditEvent.metadata.to, "reveal_pending");
+
+  const premiere = transitionCycle({
+    context: context("audit-cycle-premiere", cycleEndAt(fourWeekCycle)),
+    contributions: seededContributions,
+    cycle: pending.cycle,
+    targetStatus: "premiere",
+  });
+  assert.equal(premiere.accepted, true);
+  assert.equal(premiere.cycle.status, "premiere");
+
+  const repeatedPremiere = transitionCycle({
+    context: context("audit-cycle-premiere-repeat"),
+    contributions: seededContributions,
+    cycle: premiere.cycle,
+    targetStatus: "premiere",
+  });
+  assert.equal(repeatedPremiere.accepted, true);
+  assert.equal(repeatedPremiere.idempotent, true);
+  assert.deepEqual(repeatedPremiere.cycle, premiere.cycle);
+
+  const archived = transitionCycle({
+    context: context("audit-cycle-archived"),
+    contributions: seededContributions,
+    cycle: premiere.cycle,
+    targetStatus: "archived",
+  });
+  assert.equal(archived.accepted, true);
+  assert.equal(archived.cycle.status, "archived");
+  assertRejected(
+    transitionCycle({
+      context: context("audit-cycle-invalid"),
+      contributions: seededContributions,
+      cycle: archived.cycle,
+      targetStatus: "collecting",
+    }),
+    "invalid-transition",
+  );
+});
+
+test("failed processing follows the delayed path until retry recovery", () => {
+  const pendingCycle = { ...seededCycle, status: "reveal_pending" };
+  const failedContributions = [
+    { ...seededContributions[0], state: "failed" },
+    seededContributions[1],
+  ];
+
+  assertRejected(
+    transitionCycle({
+      context: context("audit-failure-premiere"),
+      contributions: failedContributions,
+      cycle: pendingCycle,
+      targetStatus: "premiere",
+    }),
+    "failed-contributions-require-delay",
+  );
+
+  const delayed = transitionCycle({
+    context: context("audit-cycle-delayed"),
+    contributions: failedContributions,
+    cycle: pendingCycle,
+    targetStatus: "delayed",
+  });
+  assert.equal(delayed.accepted, true);
+  assert.equal(delayed.cycle.status, "delayed");
+
+  assertRejected(
+    transitionCycle({
+      context: context("audit-delayed-still-failed"),
+      contributions: failedContributions,
+      cycle: delayed.cycle,
+      targetStatus: "premiere",
+    }),
+    "processing-failure-remains",
+  );
+
+  const recovered = transitionCycle({
+    context: context("audit-delayed-recovered"),
+    contributions: seededContributions,
+    cycle: delayed.cycle,
+    targetStatus: "premiere",
+  });
+  assert.equal(recovered.accepted, true);
+  assert.equal(recovered.cycle.status, "premiere");
+
+  assertRejected(
+    transitionCycle({
+      context: context("audit-unlocked"),
+      contributions: [
+        { ...seededContributions[0], state: "captured" },
+        seededContributions[1],
+      ],
+      cycle: pendingCycle,
+      targetStatus: "premiere",
+    }),
+    "contributions-not-locked",
+  );
+});
+
+test("local playlist is deterministic, reveal-gated, and contains contribution IDs only", () => {
+  const premiereCycle = { ...seededCycle, status: "premiere" };
+  const contributions = [
+    {
+      ...seededContributions[1],
+      id: "z-later",
+      capturedAt: "2026-08-30T09:00:00.000Z",
+      state: "locked",
+    },
+    {
+      ...seededContributions[0],
+      id: "b-earlier",
+      capturedAt: "2026-08-30T08:00:00.000Z",
+      state: "revealed",
+    },
+    {
+      ...seededContributions[0],
+      id: "a-earlier",
+      capturedAt: "2026-08-30T08:00:00.000Z",
+      state: "archived",
+    },
+    { ...seededContributions[0], id: "failed", state: "failed" },
+    { ...seededContributions[0], id: "deleted", state: "deleted" },
+    { ...seededContributions[0], id: "other-cycle", cycleId: "other" },
+  ];
+
+  const playlist = assembleLocalPlaylist(premiereCycle, contributions);
+  assert.equal(playlist.kind, "local-playlist");
+  assert.equal(playlist.cycleId, seededCycle.id);
+  assert.deepEqual(playlist.contributionIds, [
+    "a-earlier",
+    "b-earlier",
+    "z-later",
+  ]);
+  assert.equal("localUri" in playlist, false);
+  assert.equal("mediaFile" in playlist, false);
+  assert.equal("generatedMediaUri" in playlist, false);
+  assert.deepEqual(
+    assembleLocalPlaylist(premiereCycle, contributions),
+    playlist,
+  );
+
+  const beforeReveal = assembleLocalPlaylist(
+    { ...premiereCycle, status: "collecting" },
+    seededDomainFixture.contributions,
+  );
+  assert.deepEqual(beforeReveal.contributionIds, []);
+  assert.deepEqual(seededGroup.memberIds.length, 5);
+});


### PR DESCRIPTION
## Summary

- add deterministic minute, day, and four-week-equivalent simulation clock steps
- enforce collecting, reveal-pending, delayed, premiere, and archived transitions
- assemble a reveal-gated local-playlist of ordered eligible contribution IDs
- keep timezone/DST normalization, device I/O, filler policy, and media rendering outside this domain slice

## Verification

- `npm --prefix packages/domain test`
- `npm --prefix packages/domain run typecheck`
- `make check`
- `npm --prefix apps/mobile run build:web`

All pass with synthetic fixtures. See [issue 17 evidence](https://github.com/Collaboration95/rewind-v1/blob/main/evidence/issues/17/completion.md).

Closes #17